### PR TITLE
Update global metadata in docfx.json

### DIFF
--- a/UWPCommunityToolkit/docfx.json
+++ b/UWPCommunityToolkit/docfx.json
@@ -29,7 +29,15 @@
     ],
     "overwrite": [],
     "externalReference": [],
-    "globalMetadata": {},
+    "globalMetadata": {
+      "titleSuffix": "UWP Toolkit",
+      "searchScope": ["UWPtoolkit"],
+      "ms.topic": "article",
+      "ms.date": "08/30/2017",       
+      "ms.prod": "windows",
+      "ms.technology": "uwp toolkit",
+      "keywords": "uwp community toolkit"
+    },
     "fileMetadata": {},
     "template": [],
     "dest": "UWPCommunityToolkitDocs"


### PR DESCRIPTION
Update adds search scope so that search box is scoped to only UWP Comm Toolkit results by default and a title suffix for seo improvement and topic, date, product, technology, and the main keyword