### PR TITLE
Update ScrollHeader.md - Removed Obsolete Property

### DIFF
--- a/docs/controls/ScrollHeader.md
+++ b/docs/controls/ScrollHeader.md
@@ -12,16 +12,25 @@ The [ScrollHeader Control](https://docs.microsoft.com/dotnet/api/microsoft.toolk
 ## Syntax
 
 ```xaml
-<Page ...
-    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"/>
+<Page xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls" .../>
 
 <ListView Name="listView" ItemsSource="{x:Bind _items, Mode=OneWay}">
 	<ListView.Header>
-		<controls:ScrollHeader Mode="Sticky" TargetListViewBase="{x:Bind listView}">
+		<controls:ScrollHeader Mode="Sticky">
 			<TextBlock Text="Scroll Header" />
 		</controls:ScrollHeader>
 	</ListView.Header>
 </ListView>
+
+<!-- or -->
+
+<GridView Name="gridView" ItemsSource="{x:Bind _items, Mode=OneWay}">
+	<GridView.Header>
+		<controls:ScrollHeader Mode="Sticky">
+			<TextBlock Text="Scroll Header" />
+		</controls:ScrollHeader>
+	</GridView.Header>
+</GridView>
 ```
 
 ## Sample Output


### PR DESCRIPTION
Fixed issue with deprecated code in the example that leads to a failed compilation. This control now implicitly knows what the parent ListViewBase control is.

Note: The demo application already has this change, the documentation was only lagging a bit.