### PR TITLE
Add deprecation message pointing to XamlLight

### DIFF
--- a/docs/animations/Light.md
+++ b/docs/animations/Light.md
@@ -10,7 +10,8 @@ dev_langs:
 
 # Light
 
-> [!NOTE] The Light effect will be removed in a future major release. Please use [XAML lighting](https://docs.microsoft.com/en-us/windows/uwp/composition/xaml-lighting) instead.
+> [!NOTE] 
+> The Light effect will be removed in a future major release. Please use [XAML lighting](https://docs.microsoft.com/en-us/windows/uwp/composition/xaml-lighting) instead.
 
 The [Light animation](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.animations.animationextensions.light) behavior performs a point light (A point source of light that emits light in all directions) in the middle of a given UIElement. You set the distance property of the light to determine how bright the light will be. The closer the light source, the darker the UI element will be. 
 

--- a/docs/animations/Light.md
+++ b/docs/animations/Light.md
@@ -10,6 +10,8 @@ dev_langs:
 
 # Light
 
+> [!NOTE] The Light effect will be removed in a future major release. Please use [XAML lighting](https://docs.microsoft.com/en-us/windows/uwp/composition/xaml-lighting) instead.
+
 The [Light animation](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.animations.animationextensions.light) behavior performs a point light (A point source of light that emits light in all directions) in the middle of a given UIElement. You set the distance property of the light to determine how bright the light will be. The closer the light source, the darker the UI element will be. 
 
 > [!NOTE]


### PR DESCRIPTION
Issue: https://github.com/windows-toolkit/WindowsCommunityToolkit/issues/2555

Add deprecation message to Light Effect animation pointing to [XamlLight](https://docs.microsoft.com/en-us/windows/uwp/composition/xaml-lighting)