### PR TITLE
Fix post build script

### DIFF
--- a/docs/controls/wpf-winforms/WindowsXamlHost.md
+++ b/docs/controls/wpf-winforms/WindowsXamlHost.md
@@ -196,10 +196,6 @@ The following instructions uses a WPF project.
 
     <PropertyGroup>
       <HostFrameworkProject>YOUR_WPF_PROJECT_NAME</HostFrameworkProject>
-      <ObjPath>obj\$(Platform)\$(Configuration)\</ObjPath>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
-      <ObjPath>obj\$(Configuration)\</ObjPath>
     </PropertyGroup>
     <PropertyGroup>
     <!-- Copy source and build output files to hostapp folders -->
@@ -210,7 +206,7 @@ The following instructions uses a WPF project.
         copy $(TargetDir)*.xbf            $(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)
         copy $(ProjectDir)*.xaml          $(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)
         copy $(ProjectDir)*.xaml.cs       $(SolutionDir)$(HostFrameworkProject)\$(ProjectName)
-        copy $(ProjectDir)$(ObjPath)*.g.* $(SolutionDir)$(HostFrameworkProject)\$(ProjectName)
+        copy $(ProjectDir)$(IntermediateOutputPath)*.g.* $(SolutionDir)$(HostFrameworkProject)\$(ProjectName)
       </PostBuildEvent>
     </PropertyGroup>
     ```

--- a/docs/controls/wpf-winforms/WindowsXamlHost.md
+++ b/docs/controls/wpf-winforms/WindowsXamlHost.md
@@ -201,10 +201,10 @@ The following instructions uses a WPF project.
     <!-- Copy source and build output files to hostapp folders -->
     <!-- Default Winforms/WPF projects do not use $Platform for build output folder -->
       <PostBuildEvent>
-        xcopy "$(TargetDir)*.xbf"            "$(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)\"
-        xcopy "$(ProjectDir)*.xaml"          "$(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)\"
-        xcopy "$(ProjectDir)*.xaml.cs"       "$(SolutionDir)$(HostFrameworkProject)\$(ProjectName)\"
-        xcopy "$(ProjectDir)$(IntermediateOutputPath)*.g.*" "$(SolutionDir)$(HostFrameworkProject)\$(ProjectName)\"
+        xcopy "$(TargetDir)*.xbf"            "$(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)\" /Y
+        xcopy "$(ProjectDir)*.xaml"          "$(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)\" /Y
+        xcopy "$(ProjectDir)*.xaml.cs"       "$(SolutionDir)$(HostFrameworkProject)\$(ProjectName)\" /Y
+        xcopy "$(ProjectDir)$(IntermediateOutputPath)*.g.*" "$(SolutionDir)$(HostFrameworkProject)\$(ProjectName)\" /Y
       </PostBuildEvent>
     </PropertyGroup>
     ```

--- a/docs/controls/wpf-winforms/WindowsXamlHost.md
+++ b/docs/controls/wpf-winforms/WindowsXamlHost.md
@@ -201,12 +201,10 @@ The following instructions uses a WPF project.
     <!-- Copy source and build output files to hostapp folders -->
     <!-- Default Winforms/WPF projects do not use $Platform for build output folder -->
       <PostBuildEvent>
-        md $(SolutionDir)$(HostFrameworkProject)\$(ProjectName)
-        md $(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)
-        copy $(TargetDir)*.xbf            $(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)
-        copy $(ProjectDir)*.xaml          $(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)
-        copy $(ProjectDir)*.xaml.cs       $(SolutionDir)$(HostFrameworkProject)\$(ProjectName)
-        copy $(ProjectDir)$(IntermediateOutputPath)*.g.* $(SolutionDir)$(HostFrameworkProject)\$(ProjectName)
+        xcopy "$(TargetDir)*.xbf"            "$(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)\"
+        xcopy "$(ProjectDir)*.xaml"          "$(SolutionDir)$(HostFrameworkProject)\bin\$(Configuration)\$(ProjectName)\"
+        xcopy "$(ProjectDir)*.xaml.cs"       "$(SolutionDir)$(HostFrameworkProject)\$(ProjectName)\"
+        xcopy "$(ProjectDir)$(IntermediateOutputPath)*.g.*" "$(SolutionDir)$(HostFrameworkProject)\$(ProjectName)\"
       </PostBuildEvent>
     </PropertyGroup>
     ```


### PR DESCRIPTION
- Don't declare the `ObjPath` property when it's already declared by msbuild
- Use `xcopy` so build doesn't fail if files don't exist
- Quote paths so spaces in paths are allowed