### PR TITLE
Fixed use of old name for DwellProgressEventArgs in documentation.

### DIFF
--- a/docs/gaze/GazeInteractionLibrary.md
+++ b/docs/gaze/GazeInteractionLibrary.md
@@ -175,7 +175,7 @@ This library provides a default animation of a shriniking rectangle over the con
 ```
 
 ```c#
-private void OnInvokeProgress(object sender, GazeProgressEventArgs e)
+private void OnInvokeProgress(object sender, DwellProgressEventArgs e)
 {
     e.Handled = true;
 }


### PR DESCRIPTION
Fixed example code to use new name for GwellProgressEventArgs