### PR TITLE
CreateFileAsync Issue OpenIfExists

### DIFF
--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -292,11 +292,7 @@ End Using
 
 ### Known issues and limitations
 
-This service, uses [Windows.Storage](https://docs.microsoft.com/en-us/uwp/api/windows.storage) for file managing.
-
-As OneDrive's API doesn't offer the same level of collision options (or ConflictBehavior) as the ones provided by _Windows.Storage.CreationCollisionOption_, when usign the method CreateFileAsync with the parameter _OpenIfExists_, it's set to return an ArgumentException from the OneDriveHelper _TransformCollisionOptionToConflictBehavior_ method. 
-
-This method transforms the Windows Storage collision Option into OneDriveConflictBehavior parameters that are sent alongside the request to the API.
+As OneDrive's API doesn't offer the same level of collision options (or ConflictBehavior) as the ones provided by _Windows.Storage.CreationCollisionOption_, when usign the method CreateFileAsync with the parameter _OpenIfExists_, it's set to return an ArgumentException as it's not supported by the time being.
 
 
 ## Sample Code

--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -292,8 +292,11 @@ End Using
 
 ### Known issues and limitations
 
-As OneDrive's API doesn't offer the same level of collision options (or ConflictBehavior) as the ones provided by _Windows.Storage.CreationCollisionOption_, when usign the method CreateFileAsync with the parameter _OpenIfExists_, it's set to return an ArgumentException as it's not supported by the time being.
+Creating a File using the _OpenIfExists_ CollisionOption is not supported for the time being and returns an argument Exception. 
 
+This is because OneDrive's API doesn't offer the same level of collision options (or ConflictBehavior) as the ones provided by _Windows.Storage.CreationCollisionOption_ which is used for file managing. Therefore, when usign the method CreateFileAsync with the parameter _OpenIfExists_, it's set to return an ArgumentException from the OneDriveHelper _TransformCollisionOptionToConflictBehavior_ method.
+
+As a workaround, the recommended path is using _CreateCollisionOption.FailIfExists_ within a try/catch statement and opening the file whenever the error is catched, or else, manually checking previously if the file exists.
 
 ## Sample Code
 

--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -292,7 +292,8 @@ End Using
 
 ### Known issues and limitations
 
-Creating a File using the _OpenIfExists_ CollisionOption is not supported for the time being and returns an argument Exception. 
+> [!IMPORTANT]
+> Creating a File using the _OpenIfExists_ CollisionOption is not supported for the time being and returns an argument Exception. 
 
 This is because OneDrive's API doesn't offer the same level of collision options (or ConflictBehavior) as the ones provided by _Windows.Storage.CreationCollisionOption_ which is used for file managing. Therefore, when using the method CreateFileAsync with the parameter _OpenIfExists_, it's set to return an ArgumentException from the OneDriveHelper _TransformCollisionOptionToConflictBehavior_ method.
 

--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -289,7 +289,16 @@ Using stream = TryCast((Await file.StorageItemPlatformService.GetThumbnailAsync(
     Await OneDriveSampleHelpers.DisplayThumbnail(stream, "thumbnail")
 End Using
 ```
-  
+
+### Known issues and limitations
+
+This service, uses [Windows.Storage](https://docs.microsoft.com/en-us/uwp/api/windows.storage) for file managing.
+
+As OneDrive's API doesn't offer the same level of collision options (or ConflictBehavior) as the ones provided by _Windows.Storage.CreationCollisionOption_, when usign the method CreateFileAsync with the parameter _OpenIfExists_, it's set to return an ArgumentException from the OneDriveHelper _TransformCollisionOptionToConflictBehavior_ method. 
+
+This method transforms the Windows Storage collision Option into OneDriveConflictBehavior parameters that are sent alongside the request to the API.
+
+
 ## Sample Code
 
 [OneDrive Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/OneDrive%20Service). You can see this in action in [Windows Community Toolkit Sample App](https://www.microsoft.com/store/apps/9NBLGGH4TLCQ).

--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -294,7 +294,7 @@ End Using
 
 Creating a File using the _OpenIfExists_ CollisionOption is not supported for the time being and returns an argument Exception. 
 
-This is because OneDrive's API doesn't offer the same level of collision options (or ConflictBehavior) as the ones provided by _Windows.Storage.CreationCollisionOption_ which is used for file managing. Therefore, when usign the method CreateFileAsync with the parameter _OpenIfExists_, it's set to return an ArgumentException from the OneDriveHelper _TransformCollisionOptionToConflictBehavior_ method.
+This is because OneDrive's API doesn't offer the same level of collision options (or ConflictBehavior) as the ones provided by _Windows.Storage.CreationCollisionOption_ which is used for file managing. Therefore, when using the method CreateFileAsync with the parameter _OpenIfExists_, it's set to return an ArgumentException from the OneDriveHelper _TransformCollisionOptionToConflictBehavior_ method.
 
 As a workaround, the recommended path is using _CreateCollisionOption.FailIfExists_ within a try/catch statement and opening the file whenever the error is catched, or else, manually checking previously if the file exists.
 

--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -290,7 +290,7 @@ Using stream = TryCast((Await file.StorageItemPlatformService.GetThumbnailAsync(
 End Using
 ```
 
-### Known issues and limitations
+## Known issues and limitations
 
 > [!IMPORTANT]
 > Creating a File using the _OpenIfExists_ CollisionOption is not supported for the time being and returns an argument Exception. 


### PR DESCRIPTION
Added a _Known Issues_ section for the Issue caused by the OpenIfExist ColiisionOption from the CreateFileasync method that doens't have a correlative ConflictBehavior in Onedrive's API.