### PR TITLE
Add missing dev_langs headers

### DIFF
--- a/docs/controls/DropShadowPanel.md
+++ b/docs/controls/DropShadowPanel.md
@@ -3,6 +3,9 @@ title: DropShadowPanel XAML Control
 author: nmetulev
 description: The DropShadowPanel Control allows the creation of a drop shadow effect for any Xaml FrameworkElement in the markup.
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, DropShadowPanel, DropShadow, xaml Control, xaml
+dev_langs:
+  - csharp
+  - vb
 ---
 
 # DropShadowPanel XAML Control

--- a/docs/controls/Loading.md
+++ b/docs/controls/Loading.md
@@ -3,6 +3,9 @@ title: Loading XAML Control
 author: nmetulev
 description: The loading control is for showing an animation with some content when the user should wait in some tasks of the app.
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, Loading, XAML Control , xaml
+dev_langs:
+  - csharp
+  - vb
 ---
 
 # Loading XAML Control 

--- a/docs/controls/TextToolbar.md
+++ b/docs/controls/TextToolbar.md
@@ -3,6 +3,9 @@ title: TextToolbar XAML Control
 author: williamabradley
 description: The TextToolbar Control is a universal Text Editing Control for the RichEditBox Control.
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, TextToolbar, RichEditBox, XAML Control, xaml
+dev_langs:
+  - csharp
+  - vb
 ---
 
 # TextToolbar XAML Control


### PR DESCRIPTION
For #200

Added the missing document headers to enable language selection where examples are provided in both C# & VB.NET