### PR TITLE
Remove reference to `Command` property

### DIFF
--- a/docs/extensions/ListViewBase.md
+++ b/docs/extensions/ListViewBase.md
@@ -10,36 +10,13 @@ keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, ListViewBase, ext
 
 ListViewBase extensions provide a lightweight way to extend every control that inherits the <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.listviewbase" target="_blank">ListViewBase</a> class with attached properties.
 
-<br/>
-
-##### Command
-
-ListViewBase provides extension method that allow attaching ICommand to handle ListViewBase Item interaction by means of [ItemClick](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.controls.listviewbase.itemclick.aspx) event. 
-ListViewBase [IsItemClickEnabled](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.controls.listviewbase.isitemclickenabled.aspx) must be set to **true**
-
-
-
-## Example
-
-```xaml
-    // Attach the command declared in MainViewModel to ListView declared in XAML
-    // IsItemClickEnabled is set to true as shown below
-    <ListView
-        extensions:ListViewBase.Command="{x:Bind MainViewModel.ItemSelectedCommand, Mode=OneWay}"
-        IsItemClickEnabled="True"
-        ItemsSource="{x:Bind MainViewModel.Items, Mode=OneWay}"
-        SelectionMode="None" />
-```
-
-<br/>
-
-##### AlternateColor
+## AlternateColor
 
 The AlternateColor property provides a way to assign a background color to every other item.
 
 > The <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging" target="_blank">ContainerContentChanging</a> event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
 
-## Example
+### Example
 
 ```xaml
     <ListView
@@ -47,15 +24,13 @@ The AlternateColor property provides a way to assign a background color to every
         ItemsSource="{x:Bind MainViewModel.Items, Mode=OneWay}" />
 ```
 
-<br/>
-
-##### AlternateItemTemplate
+## AlternateItemTemplate
 
 The AlternateItemTemplate property provides a way to assign an alternate <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.datatemplate" target="_blank">datatemplate</a> to every other item. It is also possible to combine with the AlternateColor property.
 
 > The <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging" target="_blank">ContainerContentChanging</a> event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
 
-## Example
+### Example
 
 ```xaml
     <Page.Resources>
@@ -74,15 +49,13 @@ The AlternateItemTemplate property provides a way to assign an alternate <a href
         ItemsSource="{x:Bind MainViewModel.Items, Mode=OneWay}" />
 ```
 
-<br/>
-
-##### StretchItemContainerDirection
+## StretchItemContainerDirection
 
 The StretchItemContainerDirection property provides a way to stretch the ItemContainer in horizontal, vertical or both ways. Possible values for this property are **Horizontal**, **Vertical** and **Both**.
 
 > The <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging" target="_blank">ContainerContentChanging</a> event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
 
-## Example
+### Example
 
 ```xaml
     <ListView


### PR DESCRIPTION
That property is long since removed from the code-base.

Also corrected heading indentation.