### PR TITLE
correct "using statement" to "using directive"

### DIFF
--- a/docs/animations/Expressions.md
+++ b/docs/animations/Expressions.md
@@ -79,7 +79,7 @@ Welcome to the ExpressionBuilder classes! The ExpressionBuilder classes are a C#
 To use the ExpressionBuilder in your app, add the Microsoft.Toolkit.Uwp.UI.Animations nuget package to your project. Next, within your app project, make sure to add the using directive to leverage the ExpressionBuilder classes:
 
 ```csharp
-using  Microsoft.Toolkit.Uwp.UI.Animations.Expressions;
+using Microsoft.Toolkit.Uwp.UI.Animations.Expressions;
 ``` 
 
 Once you have the nuget package added to your project, you are all set to start using the ExpressionBuilder classes!

--- a/docs/animations/Expressions.md
+++ b/docs/animations/Expressions.md
@@ -76,7 +76,7 @@ Welcome to the ExpressionBuilder classes! The ExpressionBuilder classes are a C#
 
 ## <a name="setting-up-the-expressionbuilder-classes-with-your-app"></a>Setting up the ExpressionBuilder classes with your app
 
-To use the ExpressionBuilder in your app, add the Microsoft.Toolkit.Uwp.UI.Animations nuget package to your project. Next, within your app project, make sure to add the using statement to leverage the ExpressionBuilder classes:
+To use the ExpressionBuilder in your app, add the Microsoft.Toolkit.Uwp.UI.Animations nuget package to your project. Next, within your app project, make sure to add the using directive to leverage the ExpressionBuilder classes:
 
 ```csharp
 using  Microsoft.Toolkit.Uwp.UI.Animations.Expressions;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).

X-Ref: https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/pull/252#issuecomment-543931563