### PR TITLE
Add and fix VB code samples

### DIFF
--- a/docs/controls/Eyedropper.md
+++ b/docs/controls/Eyedropper.md
@@ -19,7 +19,8 @@ The [Eyedropper Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit
 > [Try it in the sample app](uwpct://Controls?sample=Eyedropper)
 
 ## Syntax
-- Use EyedropperToolButton in xaml.
+
+Use EyedropperToolButton in xaml.
 
 ```xaml
 <Page ...
@@ -27,11 +28,16 @@ The [Eyedropper Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit
     <controls:EyedropperToolButton />
 </Page>
 ```
-- Or use the global Eyedropper in code.
+
+Or use the global Eyedropper in code.
 
 ```csharp
 var eyedropper = new Eyedropper();
 var color = await eyedropper.Open();
+```
+```vb
+Dim eyedropper = New Eyedropper()
+Dim color = Await eyedropper.Open()
 ```
 
 ## Sample Output
@@ -88,14 +94,14 @@ var color = await eyedropper.Open();
 
 - Use the global Eyedropper in code.
 
-    ```csharp
-    var eyedropper = new Eyedropper();
-    var color = await eyedropper.Open();
-    ```
-    ```vb
-    Dim eyedropper = New Eyedropper()
-    Dim color = Await eyedropper.Open()
-    ```
+```csharp
+var eyedropper = new Eyedropper();
+var color = await eyedropper.Open();
+```
+```vb
+Dim eyedropper = New Eyedropper()
+Dim color = Await eyedropper.Open()
+```
 
 ## Sample Project
 

--- a/docs/controls/ImageCropper.md
+++ b/docs/controls/ImageCropper.md
@@ -30,7 +30,6 @@ The [ImageCropper Control](https://docs.microsoft.com/dotnet/api/microsoft.toolk
 
 ## Properties
 
-
 | Property              | Type            | Description                                                  |
 | --------------------- | --------------- | ------------------------------------------------------------ |
 | MinCroppedPixelLength | double          | Gets or sets the minimum cropped length(in pixel).           |
@@ -44,7 +43,6 @@ The [ImageCropper Control](https://docs.microsoft.com/dotnet/api/microsoft.toolk
 | SecondaryThumbStyle   | Style           | Gets or sets a value for the style to use for the secondary thumbs of the ImageCropper. |
 | ThumbPlacement        | ThumbPlacement  | Gets or sets a value for thumb placement.                    |
 
-
 ## Methods
 
 | Methods                                              | Return Type | Description                                                  |
@@ -54,10 +52,10 @@ The [ImageCropper Control](https://docs.microsoft.com/dotnet/api/microsoft.toolk
 | Reset()                                              | void        | Reset the cropped area.                                      |
 | TrySetCroppedRegion(Rect rect)                       | bool        | Tries to set a new value for the cropped region, returns true if it succeeded, false if the region is invalid  |
 
-
 ## Examples
 
 ### Use ImageCropper
+
 You can set the cropped image source by using the `LoadImageFromFile(StorageFile)` method or setting the `Source` property.
 
 ```csharp
@@ -73,7 +71,7 @@ using (var fileStream = await someFile.OpenAsync(FileAccessMode.ReadWrite, Stora
     await _imageCropper.SaveAsync(fileStream, BitmapFileFormat.Png);
 }
 ```
-``vb
+```vb
 ' Load an image.
 Await ImageCropper.LoadImageFromFile(file)
 
@@ -92,7 +90,7 @@ You can set `CropShape` property to use the circular ImageCropper.
 ```csharp
 ImageCropper.CropShape = CropShape.Circular;
 ```
-``vb
+```vb
 ImageCropper.CropShape = CropShape.Circular
 ```
 
@@ -102,7 +100,7 @@ You can set `AspectRatio` property to change the aspect ratio of the cropped ima
 ```csharp
 ImageCropper.AspectRatio = 16d / 9d;
 ```
-``vb
+```vb
 ImageCropper.AspectRatio = 16R / 9R
 ```
 
@@ -111,7 +109,7 @@ Or you can crop image without aspect ratio.
 ```csharp
 ImageCropper.AspectRatio = null;
 ```
-``vb
+```vb
 ImageCropper.AspectRatio = Nothing
 ```
 

--- a/docs/controls/wpf-winforms/MapControl.md
+++ b/docs/controls/wpf-winforms/MapControl.md
@@ -3,6 +3,9 @@ title: MapControl for Windows Forms and WPF
 author: mcleanbyron
 description: This control is a wrapper to enable use of the UWP MapControl class in Windows Forms or WPF.
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, MapControl, Windows Forms, WPF
+dev_langs:
+  - csharp
+  - vb
 ---
 
 # MapControl for Windows Forms and WPF
@@ -55,6 +58,16 @@ private async void MapControl_Loaded(object sender, RoutedEventArgs e)
     // Set the map location.
     await (sender as MapControl).TrySetViewAsync(cityCenter, 12);
 }
+```
+```vb
+Private Async Sub MapControl_Loaded(sender As Object, e As RoutedEventArgs)
+    Dim cityPosition As BasicGeoposition = New BasicGeoposition() With {
+        .Latitude = 47.604,
+        .Longitude = -122.329
+    }
+    Dim cityCenter = New Geopoint(cityPosition)
+    Await (TryCast(sender, MapControl)).TrySetViewAsync(cityCenter, 12)
+End Sub
 ```
 
 ## Properties

--- a/docs/controls/wpf-winforms/WindowsXamlHost.md
+++ b/docs/controls/wpf-winforms/WindowsXamlHost.md
@@ -3,6 +3,9 @@ title: WindowsXAMLHost control
 author: mcleanbyron
 description: This guide helps you add UWP XAML controls to your WPF.
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, host controls, xaml islands, WPF, Windows Forms
+dev_langs:
+  - csharp
+  - vb
 ---
 
 # WindowsXamlHost control for Windows Forms and WPF
@@ -97,6 +100,18 @@ Before getting started, follow these instructions to install the necessary NuGet
         MessageBox.Show("My UWP button works");
     }
     ```
+    ```vb
+    Private Sub MyWindowsXAMLHost_ChildChanged(sender As Object, e As EventArgs)
+        Dim windowsXamlHost As WindowsXamlHost = CType(sender, WindowsXamlHost)
+        Dim button As Windows.UI.Xaml.Controls.Button = CType(windowsXamlHost.Child, Windows.UI.Xaml.Controls.Button)
+        button.Content = "My UWP button"
+        AddHandler button.Click, AddressOf Button_Click
+    End Sub
+
+    Private Sub Button_Click(sender As Object, e As Windows.UI.Xaml.RoutedEventArgs)
+        MessageBox.Show("My UWP button works")
+    End Sub
+    ```
 
 ### Create and host UWP controls dynamically at run time
 
@@ -138,6 +153,36 @@ private void MyButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
 {
     MessageBox.Show("This is a UWP button.");
 }
+```
+```vb
+Private Sub UseHelperMethod()
+    Dim myHostControl As Microsoft.Toolkit.Wpf.UI.XamlHost.WindowsXamlHost = New Microsoft.Toolkit.Wpf.UI.XamlHost.WindowsXamlHost()
+
+    ' Use helper method to create a UWP control instance.
+    Dim myButton As Windows.UI.Xaml.Controls.Button = TryCast(Microsoft.Toolkit.Win32.UI.XamlHost.UWPTypeFactory.CreateXamlContentByType("Windows.UI.Xaml.Controls.Button"), Windows.UI.Xaml.Controls.Button)
+
+    ' Initialize UWP control.
+    myButton.Name = "button1"
+    myButton.Width = 75
+    myButton.Height = 40
+    myButton.TabIndex = 0
+    myButton.Content = "button1"
+    AddHandler myButton.Click, AddressOf MyButton_Click
+
+    ' initialize the Windows XAML host control.
+    myHostControl.Name = "myWindowsXamlHostControl"
+
+    ' Associate the Windows XAML host control with the UWP control.
+    ' For Windows Forms applications, you might use this.Controls.Add(myHostControl);
+    myHostControl.Child = myButton
+
+    ' Make the UWP control appear in the UI.
+    Me.MyStackPanel.Children.Add(myHostControl)
+End Sub
+
+Private Sub MyButton_Click(sender As Object, e As Windows.UI.Xaml.RoutedEventArgs)
+    MessageBox.Show("My UWP button works")
+End Sub
 ```
 
 ### Initialize UWP controls first, and then assign them to WindowsXamlHost controls
@@ -184,6 +229,40 @@ private void MyButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
 {
     MessageBox.Show("This is a UWP button.");
 }
+```
+```vb
+Private Sub CreateUWPControlsFirst()
+    ' Initialize the UWP hosting environment.
+    Windows.UI.Xaml.Hosting.WindowsXamlManager.InitializeForCurrentThread()
+
+    ' Create a UWP control.
+    Dim myButton As Windows.UI.Xaml.Controls.Button = New Windows.UI.Xaml.Controls.Button()
+
+    ' Initialize UWP control.
+    myButton.Name = "button1"
+    myButton.Width = 75
+    myButton.Height = 40
+    myButton.TabIndex = 0
+    myButton.Content = "button1"
+    AddHandler myButton.Click, AddressOf MyButton_Click
+
+    ' Create a Windows XAML host control.
+    Dim myHostControl As Microsoft.Toolkit.Wpf.UI.XamlHost.WindowsXamlHost = New Microsoft.Toolkit.Wpf.UI.XamlHost.WindowsXamlHost()
+
+    ' initialize the Windows XAML host control.
+    myHostControl.Name = "myWindowsXamlHostControl"
+
+    ' Associate the Windows XAML host control with the UWP control.
+    myHostControl.Child = myButton
+
+    ' Make the UWP control appear in the UI.
+    ' For Windows Forms applications, you might use this.Controls.Add(myHostControl);
+    Me.MyStackPanel.Children.Add(myHostControl)
+End Sub
+
+Private Sub MyButton_Click(sender As Object, e As Windows.UI.Xaml.RoutedEventArgs)
+    MessageBox.Show("My UWP button works")
+End Sub
 ```
 
 ## Sample Project


### PR DESCRIPTION
Add missing VB code samples to new controls (1 new in 6.0 & some that hadn't been done previously--I couldn't get XamlHost working in VB previously but now have)
and fix some minor formatting inconsistencies.

(was #276 - but retargeted against the correct branch and without all the extra noise.)