### PR TITLE
Title fix for SEO

### DIFF
--- a/docs/animations/ConnectedAnimations.md
+++ b/docs/animations/ConnectedAnimations.md
@@ -1,5 +1,5 @@
 ---
-title: Connected Animations XAML Attached Properties
+title: Connected Animations in XAML
 author: nmetulev
 description: The Connected Animation XAML Attached Properties enable connected animations to be defined in your XAML code
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, connected animations, animation, coordinated animations
@@ -141,8 +141,8 @@ We need to set the same key for the element to be connected with. Also, You can 
     <Border x:Name="HeroElement" Height="300"  Width="300" Background="Purple"
     animations:Connected.Key="item"/>
 
-    <StackPanel x:Name="HeroDetailsElement" Margin="20,0" 
-        VerticalAlignment="Bottom" MaxWidth="500" 
+    <StackPanel x:Name="HeroDetailsElement" Margin="20,0"
+        VerticalAlignment="Bottom" MaxWidth="500"
         animations:Connected.AnchorElement="{x:Bind HeroElement}">
         <TextBlock Text="Header" FontSize="50">Header</TextBlock>
         <TextBlock TextWrapping="WrapWholeWords">Lorem ipsum ...</TextBlock>
@@ -153,7 +153,7 @@ We need to set the same key for the element to be connected with. Also, You can 
 In this page, we can also create a GridView which implements connected animation for its items. You need to set ListItemKey and ListItemElementName for specifying the UIElement to animate.
 
 ```xaml
-<GridView x:Name="listView" Margin="0, 40, 0, 0" SelectionMode="None" 
+<GridView x:Name="listView" Margin="0, 40, 0, 0" SelectionMode="None"
 Grid.Row="1" ItemClick="ListView_ItemClick" IsItemClickEnabled="True"
 animations:Connected.ListItemElementName="ItemThumbnail"
 animations:Connected.ListItemKey="listItem">
@@ -175,14 +175,14 @@ In this page, you just need to give the same key.
 ```xaml
 <StackPanel>
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-        <StackPanel x:Name="HeroDetailsElement" Margin="20,0" VerticalAlignment="Bottom" MaxWidth="500" 
+        <StackPanel x:Name="HeroDetailsElement" Margin="20,0" VerticalAlignment="Bottom" MaxWidth="500"
         animations:Connected.AnchorElement="{x:Bind ItemHeroElement}">
-            <TextBlock Text="{x:Bind item.Title}" 
+            <TextBlock Text="{x:Bind item.Title}"
             FontSize="50"/>
             <TextBlock TextWrapping="WrapWholeWords">Lorem ipsum ...</TextBlock>
         </StackPanel>
 
-        <Border x:Name="ItemHeroElement" Height="300" Width="300" Background="Purple" 
+        <Border x:Name="ItemHeroElement" Height="300" Width="300" Background="Purple"
         animations:Connected.Key="listItem"/>
     </StackPanel>
 

--- a/docs/animations/ImplicitAnimations.md
+++ b/docs/animations/ImplicitAnimations.md
@@ -1,5 +1,5 @@
 ---
-title: Implicit Animations XAML Attached Properties
+title: Implicit Composition Animations
 author: nmetulev
 description: The Implicit Animations Attached Properties enable implicit animations to be defined in your XAML code
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, composition animations, animation, implicit animations, XAML, implicit, composition, show animation, hide animation

--- a/docs/animations/ImplicitAnimations.md
+++ b/docs/animations/ImplicitAnimations.md
@@ -1,5 +1,5 @@
 ---
-title: Implicit Composition Animations
+title: Implicit Animations in XAML
 author: nmetulev
 description: The Implicit Animations Attached Properties enable implicit animations to be defined in your XAML code
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, composition animations, animation, implicit animations, XAML, implicit, composition, show animation, hide animation

--- a/docs/controls/datagrid_guidance/rowdetails.md
+++ b/docs/controls/datagrid_guidance/rowdetails.md
@@ -1,5 +1,5 @@
 ---
-title: How to - Display and Configure Row Details in the DataGrid Control
+title: Display and Configure Row Details in DataGrid
 author: harinikmsft
 description: Guidance document that shows how to customize row details section in the DataGrid control
 keywords: windows 10, uwp, windows community toolkit, windows toolkit, DataGrid, xaml control, xaml, RowDetails
@@ -61,7 +61,7 @@ Set the **RowDetailsVisibilityMode** property to a value of the **DataGridRowDet
    * *Visible* : The row details section is displayed for all rows.
    * *VisibleWhenSelected* : The row details section is displayed only for selected rows.
 
-The following example shows how to use the RowDetailsVisibilityMode property to change the row details display mode programmatically from the selection of a value in a ComboBox: 
+The following example shows how to use the RowDetailsVisibilityMode property to change the row details display mode programmatically from the selection of a value in a ComboBox:
 
 ```C#
 // Set the row details visibility to the option selected in the combo box.
@@ -93,4 +93,4 @@ Set the **AreRowDetailsFrozen** property to true.
 * [Add a DataGrid control to a page](datagrid_basics.md)
 * [Customize the DataGrid control using styling and formatting options](styling_formatting_options.md)
 * [Sizing options in the DataGrid control](sizing_options.md)
-* [DataGrid Sample](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DataGrid). 
+* [DataGrid Sample](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DataGrid).

--- a/docs/controls/datagrid_guidance/sizing_options.md
+++ b/docs/controls/datagrid_guidance/sizing_options.md
@@ -1,5 +1,5 @@
 ---
-title: How to - Use the different sizing options in the DataGrid control
+title: Sizing options in the DataGrid control
 author: harinikmsft
 description: Guidance document that shows how to size the rows, columns and headers of the DataGrid control
 keywords: windows 10, uwp, windows community toolkit, windows toolkit, DataGrid, xaml control, xaml
@@ -50,10 +50,10 @@ The following table shows the values provided by the DataGridLengthUnitType stru
 
 | Name | Description |
 |---|---|
-| Auto | The default automatic sizing mode sizes DataGrid columns based on the contents of both cells and column headers. | 
-| SizeToCells | The cell-based automatic sizing mode sizes DataGrid columns based on the contents of cells in the column, not including column headers.| 
-| SizeToHeader | The header-based automatic sizing mode sizes DataGrid columns based on the contents of column headers only.| 
-| Pixel | The pixel-based sizing mode sizes DataGrid columns based on the numeric value provided.| 
+| Auto | The default automatic sizing mode sizes DataGrid columns based on the contents of both cells and column headers. |
+| SizeToCells | The cell-based automatic sizing mode sizes DataGrid columns based on the contents of cells in the column, not including column headers.|
+| SizeToHeader | The header-based automatic sizing mode sizes DataGrid columns based on the contents of column headers only.|
+| Pixel | The pixel-based sizing mode sizes DataGrid columns based on the numeric value provided.|
 | Star | The star sizing mode is used to distribute available space by weighted proportions. In XAML, star values are expressed as n* where n represents a numeric value. 1* is equivalent to *. For example, if two columns in a DataGrid had widths of * and 2*, the first column would receive one portion of the available space and the second column would receive two portions of the available space.
 
 The **DataGridLengthConverter** class can be used to convert data between numeric or string values and DataGridLength values.
@@ -62,14 +62,14 @@ By default, the **DataGrid.ColumnWidth** property is set to Auto, and the **Data
 
 Columns in the DataGrid can also be set to automatically size only within specified boundaries, or columns can be set to a specific size. The following table shows the properties that can be set to control column sizes.
 
-| Property | Description | 
+| Property | Description |
 |---|---|
-| DataGrid.MaxColumnWidth | Sets the upper bound for all columns in the DataGrid.| 
-| DataGridColumn.MaxWidth | Sets the upper bound for an individual column. Overrides DataGrid.MaxColumnWidth.| 
-| DataGrid.MinColumnWidth | Sets the lower bound for all columns in the DataGrid.| 
-| DataGridColumn.MinWidth | Sets the lower bound for an individual column. Overrides DataGrid.MinColumnWidth.| 
-| DataGrid.ColumnWidth | Sets a specific width for all columns in the DataGrid.| 
-| DataGridColumn.Width | Sets a specific width for an individual column. Overrides DataGrid.ColumnWidth.| 
+| DataGrid.MaxColumnWidth | Sets the upper bound for all columns in the DataGrid.|
+| DataGridColumn.MaxWidth | Sets the upper bound for an individual column. Overrides DataGrid.MaxColumnWidth.|
+| DataGrid.MinColumnWidth | Sets the lower bound for all columns in the DataGrid.|
+| DataGridColumn.MinWidth | Sets the lower bound for an individual column. Overrides DataGrid.MinColumnWidth.|
+| DataGrid.ColumnWidth | Sets a specific width for all columns in the DataGrid.|
+| DataGridColumn.Width | Sets a specific width for an individual column. Overrides DataGrid.ColumnWidth.|
 
 ### DataGrid Column Headers
 By default, DataGrid column headers are displayed. To hide column headers, the **HeadersVisibility** property must be set to *DataGridHeadersVisibility.Row* or *DataGridHeadersVisibility.None*. By default, when column headers are displayed, they automatically size to fit their content. The column headers can be given a specific height by setting the **DataGrid.ColumnHeaderHeight** property.

--- a/docs/controls/datagrid_guidance/styling_formatting_options.md
+++ b/docs/controls/datagrid_guidance/styling_formatting_options.md
@@ -1,5 +1,5 @@
 ---
-title: How to - Customize the DataGrid control through UI formatting options
+title: Customize the DataGrid control
 author: harinikmsft
 description: Guidance document that shows how to use the different formatting options to customize the look and feel of the DataGrid control
 keywords: windows 10, uwp, windows community toolkit, windows toolkit, DataGrid, xaml control, xaml
@@ -14,7 +14,7 @@ You can control the visibility of the grid lines separating inner cells using th
    * *None*: No grid lines are shown
    * *Horizontal*: Only horizontal grid lines, which separate rows, are shown.
    * *Vertical*: Only vertical grid lines, which separate columns, are shown.
-   * *All*: Both horizontal and vertical grid lines are shown. 
+   * *All*: Both horizontal and vertical grid lines are shown.
 
 You can also change the color of the gridlines using **HorizontalGridLinesBrush** and/or **VerticalGridLinesBrush** properties.
 
@@ -75,8 +75,8 @@ Frozen columns are columns that are always displayed and cannot be scrolled out 
 ![FrozenColumns](../../resources/images/Controls/DataGrid/frozencolumns.png)
 
 ## 6. Reorder and resize columns
-You can allow users to: 
-   * Adjust all column widths using mouse/touch/pen through the **DataGrid.CanUserResizeColumns** property. 
+You can allow users to:
+   * Adjust all column widths using mouse/touch/pen through the **DataGrid.CanUserResizeColumns** property.
    * Change the column display order by dragging the column headers using mouse/touch/pen through the **DataGrid.CanUserReorderColumns** property.
    * Set this behavior for individual columns by setting the **DataGridColumn.CanUserReorder/CanUserResize** properties. If the individual column properties and the global DataGrid.** properties are both set, a value of false will take precedence over a value of true.
 

--- a/docs/controls/wpf-winforms/WebView-known-issues.md
+++ b/docs/controls/wpf-winforms/WebView-known-issues.md
@@ -1,5 +1,5 @@
 ---
-title: Known Issues for WebView control for Windows Forms and WPF
+title: Known Issues in WebView control
 author: mcleanbyron
 description: This guide highlights known limitations with the current release of the WebView control for Windows Forms and WPF applications.
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, WebView, Windows Forms, WPF, known issues, release notes

--- a/docs/extensions/VisualExtensions.md
+++ b/docs/extensions/VisualExtensions.md
@@ -1,11 +1,11 @@
 ---
-title: Composition Visual Attached Properties
+title: Composition Visual Attached Properties Extension
 author: nmetulev
-description: The Composition Visual Attached Properties allow Composition Visual Properties to be modified directly in XAML
+description: The Composition Visual Attached Properties Extension allow Composition Visual Properties to be modified directly in XAML
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, Visual, composition, xaml, attached property
 ---
 
-# Composition Visual Attached Properties
+# Composition Visual Attached Properties Extension
 
 The [Composition Visual](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.visualextensions) Attached Properties allow developers to modify common properties of the [object visual](https://docs.microsoft.com/uwp/api/Windows.UI.Composition.Visual) of an element directly in XAML.
 

--- a/docs/extensions/VisualExtensions.md
+++ b/docs/extensions/VisualExtensions.md
@@ -1,5 +1,5 @@
 ---
-title: CVAP Extension
+title: Composition Visual Extension 
 author: nmetulev
 description: The Composition Visual Attached Properties Extension allow Composition Visual Properties to be modified directly in XAML
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, Visual, composition, xaml, attached property

--- a/docs/extensions/VisualExtensions.md
+++ b/docs/extensions/VisualExtensions.md
@@ -1,5 +1,5 @@
 ---
-title: Composition Visual Attached Properties Extension
+title: CVAP Extension
 author: nmetulev
 description: The Composition Visual Attached Properties Extension allow Composition Visual Properties to be modified directly in XAML
 keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, Visual, composition, xaml, attached property

--- a/docs/extensions/WebView.md
+++ b/docs/extensions/WebView.md
@@ -1,12 +1,12 @@
 ---
-title: WebView
+title: WebView extension
 author: nmetulev
 ms.date: 08/20/2017
 description: The UWP Community Toolkit WebView extensions allow attaching HTML content to WebView through XAML directly or through Binding
 keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, WebViewExtensions, webview, extensions
 ---
 
-# WebView
+# WebView extension
 
 The **WebView** extension allows attaching HTML content to WebView.
 

--- a/docs/extensions/WebView.md
+++ b/docs/extensions/WebView.md
@@ -1,14 +1,14 @@
 ---
-title: WebViewExtensions
+title: WebView
 author: nmetulev
 ms.date: 08/20/2017
 description: The UWP Community Toolkit WebView extensions allow attaching HTML content to WebView through XAML directly or through Binding
 keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, WebViewExtensions, webview, extensions
 ---
 
-# WebViewExtensions
+# WebView
 
-The **WebView** allows attaching HTML content to WebView.
+The **WebView** extension allows attaching HTML content to WebView.
 
 ## Example
 
@@ -29,4 +29,3 @@ The **WebView** allows attaching HTML content to WebView.
 ## API
 
 * [WebViewExtensions source code](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.UI/Extensions/WebView)
-

--- a/docs/extensions/WebViewExtensions.md
+++ b/docs/extensions/WebViewExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # WebViewExtensions
 
-The [WebViewExtensions](webview.md) allows attaching HTML content to WebView.
+The [WebViewExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.webviewextensions?view=win-comm-toolkit-dotnet-stable) allows attaching HTML content to WebView.
 
 ## Syntax
 

--- a/docs/extensions/WebViewExtensions.md
+++ b/docs/extensions/WebViewExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # WebViewExtensions
 
-The [WebViewExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.webview) allows attaching HTML content to WebView.
+The [WebViewExtensions](webview.md) allows attaching HTML content to WebView.
 
 ## Syntax
 
@@ -36,4 +36,3 @@ The [WebViewExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.
 ## API
 
 * [WebViewExtensions source code](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.UI/Extensions/WebView)
-


### PR DESCRIPTION
Fixing duplicate titles or overlong titles, to comply with SEO guidelines.