### PR TITLE
Add documentation for the new `ClipToBounds` property

### DIFF
--- a/docs/extensions/UIElementExtensions.md
+++ b/docs/extensions/UIElementExtensions.md
@@ -1,0 +1,55 @@
+---
+title: UIElement Extensions
+author: vgromfeld
+description: UIElementExtensions provides a simple way to extend the UIElement
+keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, UIElement, extensions
+---
+
+# UIElement Extensions
+
+`UIElementExtensions` provides helpers for `UIElement`.
+
+## ClipToBounds
+
+The `ClipToBounds` property allows you to indicate whether to clip the content of this element (or content coming from the child elements of this element) to fit into the size of the containing element.
+
+> [!div class="nextstepaction"]
+> [Try it in the sample app](uwpct://Extensions?sample=ClipToBounds)
+
+### Example
+
+```xaml
+<Grid
+    BorderBrush="White"
+    BorderThickness="1"
+    Width="148"
+    Height="148"
+    extensions:UIElementExtensions.ClipToBounds="True">
+    <!-- We translate the inner rectangles outside of the bounds of the container. -->
+    <Rectangle Fill="Blue" Width="100" Height="100">
+        <Rectangle.RenderTransform>
+            <TranslateTransform X="-50" Y="-50" />
+        </Rectangle.RenderTransform>
+    </Rectangle>
+    <Rectangle Fill="Green" Width="100" Height="100">
+        <Rectangle.RenderTransform>
+            <TranslateTransform X="50" Y="50" />
+        </Rectangle.RenderTransform>
+    </Rectangle>
+</Grid>
+
+```
+
+## Requirements (Windows 10 Device Family)
+
+| [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.16299.0 or higher |
+| --- | --- |
+| Namespace | Microsoft.Toolkit.Uwp.UI.Extensions |
+
+## API
+
+- [UIElementExtensions source code](https://github.com/Microsoft/WindowsCommunityToolkit//blob/master/Microsoft.Toolkit.Uwp.UI/Extensions/UIElement)
+
+## Related Topics
+
+- [UIElement.ClipToBounds Property (WPF)](https://docs.microsoft.com/en-us/dotnet/api/system.windows.uielement.cliptobounds?view=netframework-4.8)

--- a/docs/extensions/UIElementExtensions.md
+++ b/docs/extensions/UIElementExtensions.md
@@ -45,6 +45,7 @@ The `ClipToBounds` property allows you to indicate whether to clip the content o
 | [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.16299.0 or higher |
 | --- | --- |
 | Namespace | Microsoft.Toolkit.Uwp.UI.Extensions |
+| NuGet package | [Microsoft.Toolkit.Uwp.UI](https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.UI/) |
 
 ## API
 

--- a/docs/extensions/UIElementExtensions.md
+++ b/docs/extensions/UIElementExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # UIElement Extensions
 
-`UIElementExtensions` provides helpers for `UIElement`.
+The [UIElementExtensions](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.uielementextensions) provide helpers for `UIElement`.
 
 ## ClipToBounds
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -111,6 +111,7 @@
 ## [SurfaceDialTextboxHelper](extensions/SurfaceDialTextboxHelper.md)
 ## [TextBoxMask](extensions/TextBoxMask.md)
 ## [TextBoxRegex](extensions/TextBoxRegex.md)
+## [UIElementExtensions](extensions/UIElementExtensions.md)
 ## [ViewExtensions](extensions/ViewExtensions.md)
 ## [Visual Tree](extensions/VisualTree.md)
 ## [WebViewExtensions](extensions/WebViewExtensions.md)


### PR DESCRIPTION
The documentation for the new `UIElementExtensions.ClipToBounds` property added to the toolkit by https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/3193