### PR TITLE
Add note about running WebViewCompatible as admin

### DIFF
--- a/docs/controls/wpf-winforms/WebViewCompatible.md
+++ b/docs/controls/wpf-winforms/WebViewCompatible.md
@@ -20,6 +20,9 @@ Unlike [WebView](WebView.md), **WebViewCompatible** uses one of two rendering en
 * On devices running older versions of Windows, the [System.Windows.Controls.WebBrowser](https://docs.microsoft.com/dotnet/api/system.windows.controls.webbrowser?view=netframework-4.7.2) is used, which provides Internet Explorer engine-based rendering.
 
 > [!NOTE]
+> The Edge runtime does not at the moment work when the process is elevated as an administrator. Therefore **WebViewCompatible** will fall back to use the [System.Windows.Controls.WebBrowser](https://docs.microsoft.com/dotnet/api/system.windows.controls.webbrowser?view=netframework-4.7.2) when it detects that the process is running as administrator.
+
+> [!NOTE]
 > If you have feedback about this control, create a new issue in the [Microsoft.Toolkit.Win32 repo](https://github.com/windows-toolkit/Microsoft.Toolkit.Win32/issues) and leave your comments there. If you prefer to submit your feedback privately, you can send it to XamlIslandsFeedback@microsoft.com. Your insights and scenarios are critically important to us.
 
 > [!div class="nextstepaction"]


### PR DESCRIPTION
<!-- When opening a PR, start by forking this repository. Then, based on the type of change you're making you'll need to create a new branch from either the `master` or `live` branches:

For documentation for new features, please base your fork off the master branch.

If you have a typo or existing document improvement to an already shipped feature, please base your change off of the [live branch](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/tree/live).  This will allow us to get the change to the published documentation between releases.

We will periodically merge updates from the live branch to master to keep master in-sync with the published docs.  When we make a new release, we will push master to the live branch in order to publish documentation for new features.

Documentation Links
**This link is currently only available for Microsoft Employees** - [Staging review from 'master' branch](https://review.docs.microsoft.com/windows/communitytoolkit/?branch=master)
- [Live site from 'live' branch](https://docs.microsoft.com/windows/communitytoolkit) -->

## Docs for Toolkit PR [#](https://github.com/windows-toolkit/WindowsCommunityToolkit/pulls/#) https://github.com/windows-toolkit/Microsoft.Toolkit.Win32/pull/250
https://github.com/windows-toolkit/Microsoft.Toolkit.Win32/issues/13

## What changes to the docs does this PR provide?
Added note about the fall back to IE controls when running `WebViewCompatible` in an elevated process

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Correctly picked the right branch to base the change off (`master` for new features, `live` for typos/improvements)
- [ ] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/.template.md) *(N/A)*
- [ ] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/toc.md) *(N/A)*
- [x] Ran against a spell and grammar checker 
- [x] Contains **NO** breaking changes
