### PR TITLE
Change RssParser to Migration Doc for #378

### DIFF
--- a/docs/.template.md
+++ b/docs/.template.md
@@ -92,7 +92,7 @@ The [Control Name](API-Link) ...
 ## Sample Project
 
 <!-- Link to the sample page in the Windows Community Toolkit Sample App -->
-[control/helper name sample page Source](sample-page-link). You can [see this in action](uwpct://CategoryName?sample=pageName) in [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[control/helper name sample page Source](sample-page-link). You can [see this in action](uwpct://CategoryName?sample=pageName) in [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 

--- a/docs/archive/graph/AadLogin.md
+++ b/docs/archive/graph/AadLogin.md
@@ -57,7 +57,7 @@ The [AadLogin Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.u
 
 ## Sample Code
 
-First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
+First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
 
 ```c#
 MicrosoftGraphService.Instance.AuthenticationModel = MicrosoftGraphEnums.AuthenticationModel.V2;
@@ -69,7 +69,7 @@ MicrosoftGraphService.Instance.Initialize(
 );
 ```
 
-[AadLogin Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AadLogin). You can [see this in action](uwpct://Controls?sample=AadLogin) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[AadLogin Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AadLogin). You can [see this in action](uwpct://Controls?sample=AadLogin) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Default Template
 

--- a/docs/archive/graph/AadLogin.md
+++ b/docs/archive/graph/AadLogin.md
@@ -7,6 +7,9 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # AadLogin Control
 
+> [!WARNING]
+> (This API has been removed. For the latest guidance on using the Microsoft Graph see the [LoginButton](../../graph/controls/LoginButton.md) control.)
+
 The [AadLogin Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.controls.graph.aadlogin) leverages existing .NET login libraries to support basic AAD sign-in processes for Microsoft Graph, it relies on the [MicrosoftGraphService](../../services/MicrosoftGraph.md) for authentication.
 
 ## Syntax

--- a/docs/archive/graph/PeoplePicker.md
+++ b/docs/archive/graph/PeoplePicker.md
@@ -10,7 +10,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 > [!WARNING]
 > (This API has been removed. For the latest guidance on using the Microsoft Graph see the new [PeoplePicker](../../graph/controls/PeoplePicker.md) control.)
 
-The [PeoplePicker Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.controls.graph.peoplepicker) is a simple control that allows for selection of one or more users from an organizational AD, see more details [here](https://developer.microsoft.com/en-us/graph/docs/concepts/people_example), it relies on the [MicrosoftGraphService](../../services/MicrosoftGraph.md) for authentication.
+The [PeoplePicker Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.controls.graph.peoplepicker) is a simple control that allows for selection of one or more users from an organizational AD, see more details [here](https://developer.microsoft.com/graph/docs/concepts/people_example), it relies on the [MicrosoftGraphService](../../services/MicrosoftGraph.md) for authentication.
 
 ## Syntax
 
@@ -39,7 +39,7 @@ The [PeoplePicker Control](https://docs.microsoft.com/dotnet/api/microsoft.toolk
 
 ## Sample Code
 
-First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
+First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
 
 ```c#
 MicrosoftGraphService.Instance.AuthenticationModel = MicrosoftGraphEnums.AuthenticationModel.V2;
@@ -57,7 +57,7 @@ The sign in will be processed by the [AadLogin](AadLogin.md) control, however, y
 await MicrosoftGraphService.Instance.LoginAsync();
 ```
 
-[PeoplePicker Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PeoplePicker). You can [see this in action](uwpct://Controls?sample=PeoplePicker) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[PeoplePicker Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PeoplePicker). You can [see this in action](uwpct://Controls?sample=PeoplePicker) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Default Template
 

--- a/docs/archive/graph/PeoplePicker.md
+++ b/docs/archive/graph/PeoplePicker.md
@@ -7,6 +7,9 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # PeoplePicker Control
 
+> [!WARNING]
+> (This API has been removed. For the latest guidance on using the Microsoft Graph see the new [PeoplePicker](../../graph/controls/PeoplePicker.md) control.)
+
 The [PeoplePicker Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.controls.graph.peoplepicker) is a simple control that allows for selection of one or more users from an organizational AD, see more details [here](https://developer.microsoft.com/en-us/graph/docs/concepts/people_example), it relies on the [MicrosoftGraphService](../../services/MicrosoftGraph.md) for authentication.
 
 ## Syntax

--- a/docs/archive/graph/PlannerTaskList.md
+++ b/docs/archive/graph/PlannerTaskList.md
@@ -38,9 +38,9 @@ The [PlannerTaskList Control](https://docs.microsoft.com/dotnet/api/microsoft.to
 
 ## Sample Code
 
-First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
+First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
 
-> Note: The permission `Group.ReadWrite.All` used in this control requires [admin consent](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes#request-the-permissions-from-a-directory-admin), which could be done by opening URL like this in browser and sign in with your organization's admin.
+> Note: The permission `Group.ReadWrite.All` used in this control requires [admin consent](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-scopes#request-the-permissions-from-a-directory-admin), which could be done by opening URL like this in browser and sign in with your organization's admin.
 > `https://login.microsoftonline.com/common/adminconsent?client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx&state=12345`
 
 ```c#
@@ -59,7 +59,7 @@ The sign in will be processed by the [AadLogin](AadLogin.md) control, however, y
 await MicrosoftGraphService.Instance.LoginAsync();
 ```
 
-[PlannerTaskList Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PlannerTaskList). You can [see this in action](uwpct://Controls?sample=PlannerTaskList) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[PlannerTaskList Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PlannerTaskList). You can [see this in action](uwpct://Controls?sample=PlannerTaskList) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Default Template
 

--- a/docs/archive/graph/PlannerTaskList.md
+++ b/docs/archive/graph/PlannerTaskList.md
@@ -40,7 +40,7 @@ The [PlannerTaskList Control](https://docs.microsoft.com/dotnet/api/microsoft.to
 
 First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
 
-> Note: The permission `Group.ReadWrite.All` used in this control requires [admin consent](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-scopes#request-the-permissions-from-a-directory-admin), which could be done by opening URL like this in browser and sign in with your organization's admin.
+> Note: The permission `Group.ReadWrite.All` used in this control requires [admin consent](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-scopes#request-the-permissions-from-a-directory-admin), which could be done by opening a URL like this in the browser and sign in with your organization's admin.
 > `https://login.microsoftonline.com/common/adminconsent?client_id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx&state=12345`
 
 ```c#

--- a/docs/archive/graph/PlannerTaskList.md
+++ b/docs/archive/graph/PlannerTaskList.md
@@ -7,6 +7,9 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # PlannerTaskList Control
 
+> [!WARNING]
+> (This API has been removed. For the latest guidance on using the Microsoft Graph see the [InteractiveProviderBehavior](../../graph/providers/InteractiveProviderBehavior.md).)
+
 The [PlannerTaskList Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.controls.graph.plannertasklist) displays a simple list of Planner tasks, it relies on the [MicrosoftGraphService](../../services/MicrosoftGraph.md) for authentication.
 
 ## Syntax

--- a/docs/archive/graph/PowerBIEmbedded.md
+++ b/docs/archive/graph/PowerBIEmbedded.md
@@ -61,7 +61,7 @@ The [PowerBIEmbedded Control](https://docs.microsoft.com/dotnet/api/microsoft.to
         ![PowerBIEmbedded Permissions](../../resources/images/Graph/PowerBIEmbedded-Permissions.png)
 
 <!-- workaround for bullets styling -->
-2. Follow this [article](https://docs.microsoft.com/en-us/power-bi/developer/embedding-content) to do the primary tasks below.
+2. Follow this [article](https://docs.microsoft.com/power-bi/developer/embedding-content) to do the primary tasks below.
 
    * Create Power BI Pro user account
    * Create app workspaces
@@ -69,11 +69,11 @@ The [PowerBIEmbedded Control](https://docs.microsoft.com/dotnet/api/microsoft.to
    * Create and publish reports
 
 <!-- workaround for bullets styling -->
-3. For better report experience in mobile, that's recommended to [design phone layout for mobile portrait view in PowerBI desktop](https://docs.microsoft.com/en-us/power-bi/desktop-create-phone-report).
+3. For better report experience in mobile, that's recommended to [design phone layout for mobile portrait view in PowerBI desktop](https://docs.microsoft.com/power-bi/desktop-create-phone-report).
 
 ## Sample Project
 
-[PowerBIEmbedded Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PowerBIEmbedded). You can [see this in action](uwpct://Controls?sample=PowerBIEmbedded) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[PowerBIEmbedded Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PowerBIEmbedded). You can [see this in action](uwpct://Controls?sample=PowerBIEmbedded) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Default Template
 

--- a/docs/archive/graph/PowerBIEmbedded.md
+++ b/docs/archive/graph/PowerBIEmbedded.md
@@ -7,6 +7,9 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # PowerBIEmbedded Control
 
+> [!WARNING]
+> (This API has been removed. For the latest guidance on using the Microsoft Graph see the [InteractiveProviderBehavior](../../graph/providers/InteractiveProviderBehavior.md).)
+
 The [PowerBIEmbedded Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.controls.graph.powerbiembedded) is a simple wrapper to an IFRAME for a PowerBI embed.
 
 ## Syntax

--- a/docs/archive/graph/ProfileCard.md
+++ b/docs/archive/graph/ProfileCard.md
@@ -41,7 +41,7 @@ The [ProfileCard Control](https://docs.microsoft.com/dotnet/api/microsoft.toolki
 
 ## Sample Code
 
-First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
+First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
 
 ```c#
 MicrosoftGraphService.Instance.AuthenticationModel = MicrosoftGraphEnums.AuthenticationModel.V2;
@@ -59,7 +59,7 @@ The sign in will be processed by the [AadLogin](AadLogin.md) control, however, y
 await MicrosoftGraphService.Instance.LoginAsync();
 ```
 
-[ProfileCard Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ProfileCard). You can [see this in action](uwpct://Controls?sample=ProfileCard) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[ProfileCard Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ProfileCard). You can [see this in action](uwpct://Controls?sample=ProfileCard) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Default Template
 

--- a/docs/archive/graph/ProfileCard.md
+++ b/docs/archive/graph/ProfileCard.md
@@ -7,6 +7,9 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # ProfileCard Control
 
+> [!WARNING]
+> (This API has been removed. For the latest guidance on using the Microsoft Graph see the [PersonView](../../graph/controls/PersonView.md).)
+
 The [ProfileCard Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.controls.graph.profilecard) is a simple way to display a user in multiple different formats and mixes of name/image/e-mail, it relies on the [MicrosoftGraphService](../../services/MicrosoftGraph.md) for authentication.
 
 ## Syntax

--- a/docs/archive/graph/SharePointFileList.md
+++ b/docs/archive/graph/SharePointFileList.md
@@ -56,7 +56,7 @@ The [SharePointFileList Control](https://docs.microsoft.com/dotnet/api/microsoft
 
 ## Sample Code
 
-First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
+First of all, initialize the [MicrosoftGraphService](../../services/MicrosoftGraph.md) with your [Azure AD v2.0 app](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-app-registration), this should be done globally with the combined and unique [delegate permissions](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-scopes) required by all Graph controls and services used in your app.
 
 ```c#
 MicrosoftGraphService.Instance.AuthenticationModel = MicrosoftGraphEnums.AuthenticationModel.V2;
@@ -74,7 +74,7 @@ The sign in will be processed by the [AadLogin](AadLogin.md) control, however, y
 await MicrosoftGraphService.Instance.LoginAsync();
 ```
 
-[SharePointFileList Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SharePointFileList). You can [see this in action](uwpct://Controls?sample=SharePointFileList) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[SharePointFileList Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SharePointFileList). You can [see this in action](uwpct://Controls?sample=SharePointFileList) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Default Template
 

--- a/docs/archive/graph/SharePointFileList.md
+++ b/docs/archive/graph/SharePointFileList.md
@@ -7,6 +7,9 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # SharePointFileList Control
 
+> [!WARNING]
+> (This API has been removed. For the latest guidance on using the Microsoft Graph see the [InteractiveProviderBehavior](../../graph/providers/InteractiveProviderBehavior.md).)
+
 The [SharePointFileList Control](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.controls.graph.sharepointfilelist) displays a simple list of SharePoint Files, it relies on the [MicrosoftGraphService](../../services/MicrosoftGraph.md) for authentication.
 
 ## Syntax

--- a/docs/helpers/HttpHelper.md
+++ b/docs/helpers/HttpHelper.md
@@ -11,7 +11,7 @@ dev_langs:
 # HttpHelper
 
 > [!WARNING]
-> (This API is obsolete and will be removed in the future. Please use [System.Net.Http.HttpClient](https://msdn.microsoft.com/library/system.net.http.httpclient(v=vs.110).aspx) or [Windows.Web.Http.HttpClient](https://docs.microsoft.com/uwp/api/Windows.Web.Http.HttpClient) directly)
+> (This API is obsolete and has been removed. Please use [System.Net.Http.HttpClient](https://msdn.microsoft.com/library/system.net.http.httpclient(v=vs.110).aspx) or [Windows.Web.Http.HttpClient](https://docs.microsoft.com/uwp/api/Windows.Web.Http.HttpClient) directly)
 
 The [HttpHelper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.httphelper) represents an HTTP request message including headers.
 

--- a/docs/helpers/HttpHelperRequest.md
+++ b/docs/helpers/HttpHelperRequest.md
@@ -11,7 +11,7 @@ dev_langs:
 # HttpHelperRequest
 
 > [!WARNING]
-> (This API is obsolete and will be removed in the future. Please use [System.Net.Http.HttpRequestMessage](https://msdn.microsoft.com/library/system.net.http.httprequestmessage(v=vs.110).aspx) 
+> (This API is obsolete and has been removed. Please use [System.Net.Http.HttpRequestMessage](https://msdn.microsoft.com/library/system.net.http.httprequestmessage(v=vs.110).aspx) 
 > or [Windows.Web.Http.HttpRequestMessage](https://docs.microsoft.com/uwp/api/windows.web.http.httprequestmessage) directly)
 
 The [HttpHelperRequest](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.httphelperrequest) represents an HTTP request message including headers. 

--- a/docs/helpers/HttpHelperRequest.md
+++ b/docs/helpers/HttpHelperRequest.md
@@ -30,7 +30,7 @@ The **HttpHelperRequest** class has these constructors.
 | Constructor | Description |
 | ----------  | ----------- |
 | HttpHelperRequest([Uri](https://msdn.microsoft.com/library/system.uri.aspx))  | Initializes a new instance of the HttpHelperRequest class with an HTTP Get method and a request Uri.|
-| HttpHelperRequest([HttpMethod](https://msdn.microsoft.com/en-us/library/windows/apps/windows.web.http.httpmethod.aspx), [Uri](https://msdn.microsoft.com/library/system.uri.aspx))  | Initializes a new instance of the HttpRequestMessage class with an HTTP method and a request Uri.|
+| HttpHelperRequest([HttpMethod](https://msdn.microsoft.com/library/windows/apps/windows.web.http.httpmethod.aspx), [Uri](https://msdn.microsoft.com/library/system.uri.aspx))  | Initializes a new instance of the HttpRequestMessage class with an HTTP method and a request Uri.|
 
 ## Methods
 
@@ -38,7 +38,7 @@ The **HttpHelperRequest** class has these methods. It also inherits from **Objec
 
 | Method | Description |
 | ------ | ----------- |
-| ToHttpRequestMessage() | Returns an instance of [**HttpRequestMessage**](https://msdn.microsoft.com/en-us/library/windows/apps/windows.web.http.httprequestmessage.aspx) representing current HttpHelperRequest object. |
+| ToHttpRequestMessage() | Returns an instance of [**HttpRequestMessage**](https://msdn.microsoft.com/library/windows/apps/windows.web.http.httprequestmessage.aspx) representing current HttpHelperRequest object. |
 | Dispose() | Performs tasks associated with freeing, releasing, or resetting unmanaged resources. |
 | ToString() | Returns a string that represents the current HttpHelperRequest object. |
 

--- a/docs/helpers/HttpHelperResponse.md
+++ b/docs/helpers/HttpHelperResponse.md
@@ -11,7 +11,7 @@ dev_langs:
 # HttpHelperResponse
 
 > [!WARNING]
-> (This API is obsolete and will be removed in the future. Please use [System.Net.Http.HttpResponseMessage](https://msdn.microsoft.com/library/system.net.http.httpresponsemessage(v=vs.110).aspx) 
+> (This API is obsolete and has been removed. Please use [System.Net.Http.HttpResponseMessage](https://msdn.microsoft.com/library/system.net.http.httpresponsemessage(v=vs.110).aspx) 
 > or [Windows.Web.Http.HttpResponseMessage](https://docs.microsoft.com/uwp/api/Windows.Web.Http.HttpResponseMessage) directly)
 
 [HttpHelperResponse](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.httphelperresponse) represents an HTTP response message including headers. 

--- a/docs/helpers/HttpHelperResponse.md
+++ b/docs/helpers/HttpHelperResponse.md
@@ -16,7 +16,7 @@ dev_langs:
 
 [HttpHelperResponse](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.httphelperresponse) represents an HTTP response message including headers. 
 
-## Example
+## Sample
 
 ```csharp
 using (HttpHelperResponse response = await HttpHelper.Instance.SendRequestAsync(request))
@@ -36,7 +36,7 @@ The **HttpHelperResponse** class has these constructors.
 
 | Constructor | Description |
 | ----------  | ----------- |
-| HttpHelperResponse([HttpResponseMessage](https://msdn.microsoft.com/en-us/library/windows/apps/windows.web.http.httpresponsemessage.aspx))  | Initializes an instance of the HttpHelperRequest class with supplied HttpHelperResponse. |
+| HttpHelperResponse([HttpResponseMessage](https://msdn.microsoft.com/library/windows/apps/windows.web.http.httpresponsemessage.aspx))  | Initializes an instance of the HttpHelperRequest class with supplied HttpHelperResponse. |
 
 ## Properties
 

--- a/docs/parsers/MarkdownParser.md
+++ b/docs/parsers/MarkdownParser.md
@@ -10,6 +10,9 @@ dev_langs:
 
 # Markdown Parser
 
+> [!WARNING]
+> (This API is will be removed in the future. Please consider using [Markdig](https://github.com/lunet-io/markdig) for Markdown document parsing. 
+
 The [MarkdownDocument](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.parsers.markdown.markdowndocument) class allows you to parse a Markdown String into a Markdown Document, and then Render it with a Markdown Renderer.
 
 > [!div class="nextstepaction"]

--- a/docs/parsers/MarkdownParser.md
+++ b/docs/parsers/MarkdownParser.md
@@ -13,7 +13,7 @@ dev_langs:
 > [!WARNING]
 > (This API is will be removed in the future. Please consider using [Markdig](https://github.com/lunet-io/markdig) for Markdown document parsing. 
 
-The [MarkdownDocument](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.parsers.markdown.markdowndocument) class allows you to parse a Markdown String into a Markdown Document, and then Render it with a Markdown Renderer.
+The [MarkdownDocument](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.parsers.markdown.markdowndocument) class allows you to parse a Markdown String into a Markdown Document, and then Render it with a Markdown Renderer.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=Markdown%20Parser)
@@ -79,7 +79,7 @@ The best way to figure out how to create a Renderer, is to look at the [implemen
 
 ## Sample Project
 
-[Markdown Parser Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//blob/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/MarkdownParser/MarkdownParserPage.xaml.cs). You can [see this in action](uwpct://Helpers?sample=Markdown%20Parser) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[Markdown Parser Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//blob/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/MarkdownParser/MarkdownParserPage.xaml.cs). You can [see this in action](uwpct://Helpers?sample=Markdown%20Parser) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 

--- a/docs/parsers/RSSParser.md
+++ b/docs/parsers/RSSParser.md
@@ -1,6 +1,6 @@
 ---
 title: RSS Parser
-author: williamabradley
+author: michael-hawker
 description: The RSS Parser allows you to parse an RSS content String into an RSS Schema.
 keywords: windows community toolkit, uwp community toolkit, uwp toolkit, microsoft community toolkit, microsoft toolkit, rss, rss parsing, parser
 dev_langs:
@@ -10,12 +10,19 @@ dev_langs:
 
 # RSS Parser
 
-The [RssParser](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.parsers.rss.rssparser) class allows you to parse an RSS content String into an RSS Schema.
+The Toolkit RssParser has been removed. Code should be migrated to use the [System.ServiceModel.Syndication](https://docs.microsoft.com/dotnet/api/system.servicemodel.syndication) API instead.
 
-> [!div class="nextstepaction"]
-> [Try it in the sample app](uwpct://Helpers?sample=RSS%20Parser)
+This document will show you how to migrate over to the .NET Standard library API.
 
-## Example
+## Migration Steps
+
+1. Remove the `Microsoft.Toolkit.Parsers` package.
+2. Add the `System.ServiceModel.Syndication` package.
+3. Replace `HttpClient` + `GetStringAsync` with `XmlReader.Create`.
+4. Replace `RssParser` + `Parse` with `SyndicationFeed.Load`.
+5. Append `.Text` to any element properties retrieved.
+
+## Toolkit Example
 
 ```csharp
 public async void ParseRSS()
@@ -28,7 +35,7 @@ public async void ParseRSS()
         {
             feed = await client.GetStringAsync("https://visualstudiomagazine.com/rss-feeds/news.aspx");
         }
-        catch { }
+        catch { } // TODO: Deal with unavailable resource.
     }
 
     if (feed != null)
@@ -65,32 +72,47 @@ Public Async Sub ParseRSS()
 End Sub
 ```
 
-## Classes
+## .NET Example
 
-| Class | Purpose |
-| --- | --- |
-| **Microsoft.Toolkit.Parsers.Rss.RssParser** | Parser for Parsing RSS Strings into RSS Schema. |
-| **Microsoft.Toolkit.Parsers.Rss.RssSchema** | Schema for Parsing RSS. |
+```cs
+public void ParseRSSdotnet()
+{
+    SyndicationFeed feed = null;
 
-### RssParser
+    try
+    {
+        using (var reader = XmlReader.Create("https://visualstudiomagazine.com/rss-feeds/news.aspx"))
+        {
+            feed = SyndicationFeed.Load(reader);
+        }
+    }
+    catch { } // TODO: Deal with unavailable resource.
 
-#### Methods
-
-| Methods | Return Type | Description |
-| -- | -- | -- |
-| Parse(string) | IEnumerable\<RssSchema\> | Parse an RSS content string into RSS Schema. |
-
-## Sample Project
-
-[RSS Parser Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//blob/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RssParser/RssParserPage.xaml.cs). You can [see this in action](uwpct://Helpers?sample=RSS%20Parser) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
-
-## Requirements
-
-| Implementation | .NET Standard 1.4. |
-| -- | -- |
-| Namespace | Microsoft.Toolkit.Parsers |
-| NuGet package | [Microsoft.Toolkit.Parsers](https://www.nuget.org/packages/Microsoft.Toolkit.Parsers/)  |
-
-## API Source Code
-
-* [RSS Parser source code](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Parsers/Rss)
+    if (feed != null)
+    {
+        foreach (var element in feed.Items)
+        {
+            Console.WriteLine($"Title: {element.Title.Text}");
+            Console.WriteLine($"Summary: {element.Summary.Text}");
+        }
+    }
+}
+```
+```vb
+Public Sub ParseRSSdotnet()
+    Dim feed As SyndicationFeed = Nothing
+    Try
+        Using reader = XmlReader.Create("https://visualstudiomagazine.com/rss-feeds/news.aspx")
+            feed = SyndicationFeed.Load(reader)
+        End Using
+    Catch
+    End Try
+    
+    If feed IsNot Nothing Then
+        For Each element In feed.Items
+            Console.WriteLine($"Title: {element.Title.Text}")
+            Console.WriteLine($"Summary: {element.Summary.Text}")
+        Next
+    End If
+End Sub
+```

--- a/docs/parsers/RSSParser.md
+++ b/docs/parsers/RSSParser.md
@@ -22,6 +22,9 @@ This document will show you how to migrate over to the .NET Standard library API
 4. Replace `RssParser` + `Parse` with `SyndicationFeed.Load`.
 5. Append `.Text` to any element properties retrieved.
 
+> [!WARNING]
+> If updating a UWP based project, Visual Studio will recommend the `Windows.Web.Syndication` namespace by default. Be sure to ignore this suggestion and instead include the `System.ServiceModel.Syndication` NuGet package and namespace instead.
+
 ## Toolkit Example
 
 ```csharp

--- a/docs/parsers/RSSParser.md
+++ b/docs/parsers/RSSParser.md
@@ -23,7 +23,8 @@ This document will show you how to migrate over to the .NET Standard library API
 5. Append `.Text` to any element properties retrieved.
 
 > [!WARNING]
-> If updating a UWP based project, Visual Studio will recommend the `Windows.Web.Syndication` namespace by default. Be sure to ignore this suggestion and instead include the `System.ServiceModel.Syndication` NuGet package and namespace instead.
+> If updating a UWP based project, Visual Studio will recommend the `Windows.Web.Syndication` namespace by default. Be sure to ignore this suggestion and instead include the `System.ServiceModel.Syndication` NuGet package and namespace.
+
 
 ## Toolkit Example
 

--- a/docs/parsers/RSSParser.md
+++ b/docs/parsers/RSSParser.md
@@ -116,3 +116,7 @@ Public Sub ParseRSSdotnet()
     End If
 End Sub
 ```
+
+## Related Topics
+
+* [SyndicationFeed Class](https://docs.microsoft.com/dotnet/api/system.servicemodel.syndication.syndicationfeed)

--- a/docs/services/Facebook.md
+++ b/docs/services/Facebook.md
@@ -279,7 +279,7 @@ Class for connecting to Facebook
 
 ## Sample Project
 
-[Facebook Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook%20Service). You can [see this in action](uwpct://Services?sample=Facebook%20Service) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[Facebook Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook%20Service). You can [see this in action](uwpct://Services?sample=Facebook%20Service) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 

--- a/docs/services/Facebook.md
+++ b/docs/services/Facebook.md
@@ -10,6 +10,9 @@ dev_langs:
 
 # Facebook Service
 
+> [!WARNING]
+> The Facebook Service is no longer available in the Windows Community Toolkit. The underlying dependent library was no longer maintained.
+
 The Facebook Service allows you to retrieve or publish data to the Facebook graph. Examples of the types of objects you can work with are Posts, Tagged Objects, and the primary user feed.
 
 > [!div class="nextstepaction"]

--- a/docs/services/GraphLogin.md
+++ b/docs/services/GraphLogin.md
@@ -9,6 +9,10 @@ dev_langs:
 ---
 
 # GraphLogin Component
+
+> [!WARNING]
+> (This API has been removed. For the latest guidance on using the Microsoft Graph see the [LoginButton](../graph/controls/LoginButton.md) control.)
+
 <!-- Describe your control -->
 The GraphLogin component is a Windows Forms component that provides an easy to use experience for authenticating with Azure AD and the Microsoft Graph.  This component is being provided for Windows Forms developers that need a Microsoft Graph authentication solution on Windows 10 builds 1803 and earlier and on Windows 7.
 

--- a/docs/services/GraphLogin.md
+++ b/docs/services/GraphLogin.md
@@ -19,7 +19,7 @@ The GraphLogin component is a Windows Forms component that provides an easy to u
 This component wraps the Toolkit's **MicrosoftGraphService** for an easy to use Login experience.  The control then provides read-only properties about the logged on user and an instance of the **GraphServiceClient** which can be used for additional calls with the Microsoft Graph SDK.
 
 > [!IMPORTANT]
-> Before using this component, the application must be registered in the Azure AD v2 endpoint.  For more information on registering your app see https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-app-registration.
+> Before using this component, the application must be registered in the Azure AD v2 endpoint.  For more information on registering your app see https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-app-registration.
 
 
 ## Syntax

--- a/docs/services/Linkedin.md
+++ b/docs/services/Linkedin.md
@@ -94,7 +94,7 @@ The toolkit has implementations of each of them for UWP. You can find them as Uw
 
 ## Sample Project
 
-[LinkedIn Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/LinkedIn%20Service). You can [see this in action](uwpct://Services?sample=LinkedIn%20Service) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[LinkedIn Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/LinkedIn%20Service). You can [see this in action](uwpct://Services?sample=LinkedIn%20Service) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 

--- a/docs/services/Linkedin.md
+++ b/docs/services/Linkedin.md
@@ -10,6 +10,9 @@ dev_langs:
 
 # LinkedIn Service
 
+> [!WARNING]
+> (This API will be removed in the future.)
+
 The **LinkedIn Service** allows you to retrieve or publish data to the LinkedIn graph. Examples of the types of objects you can work with are User profile data and sharing Activity.
 
 > [!div class="nextstepaction"]

--- a/docs/services/MicrosoftGraph.md
+++ b/docs/services/MicrosoftGraph.md
@@ -57,7 +57,7 @@ After you've registered your app, Azure AD will generate a client ID for your ap
 
 When you register your app in the [Azure Management Portal](https://portal.azure.com), you will need to configure details about your application with the following steps:
 
-1. Click "Settings" button
+1. Click the "Settings" button
 2. Go to the "Required permissions" option
 3. Add Application: Choose **Microsoft Graph** API 
 4. Specify the permission levels the MicrosoftGraph Service requires from the Office 365 API (Microsoft Graph). Choose at least:

--- a/docs/services/MicrosoftGraph.md
+++ b/docs/services/MicrosoftGraph.md
@@ -46,7 +46,7 @@ You can register your app manually by using the [Azure Management Portal](https:
 2. To register your app manually, see [Manually register your app with Azure AD so it can access Office 365 APIs.](https://msdn.microsoft.com/office/office365/howto/add-common-consent-manually). Here is a summary to register your App manually:
     - Go to the [Azure Management Portal](https://portal.azure.com)
     - Go to the "Azure Active Directory" option
-    - Go to "App Registrations" option
+    - Go to the "App Registrations" option
     - Click on the "New application registration" button
     - Enter a name for your App
     - Specify your application as a **Native**

--- a/docs/services/MicrosoftGraph.md
+++ b/docs/services/MicrosoftGraph.md
@@ -10,6 +10,9 @@ dev_langs:
 
 # MicrosoftGraph Service
 
+> [!WARNING]
+> (This API has been removed. For the latest guidance on using the Microsoft Graph see the [InteractiveProviderBehavior](../graph/providers/InteractiveProviderBehavior.md).)
+
 The **MicrosoftGraph** Service allows easy access to the Microsoft Graph in order to:
 
 * Retrieve User Information

--- a/docs/services/MicrosoftGraph.md
+++ b/docs/services/MicrosoftGraph.md
@@ -58,7 +58,7 @@ After you've registered your app, Azure AD will generate a client ID for your ap
 When you register your app in the [Azure Management Portal](https://portal.azure.com), you will need to configure details about your application with the following steps:
 
 1. Click "Settings" button
-2. Go to "Required permissions" option
+2. Go to the "Required permissions" option
 3. Add Application: Choose **Microsoft Graph** API 
 4. Specify the permission levels the MicrosoftGraph Service requires from the Office 365 API (Microsoft Graph). Choose at least:
    * **Sign in and read user profile** to access user's profile.

--- a/docs/services/MicrosoftGraph.md
+++ b/docs/services/MicrosoftGraph.md
@@ -41,10 +41,10 @@ To authenticate your app, you need to register your app with Azure AD, and provi
 
 ### Register the App to use Azure AD v1 Endpoint
 
-You can register your app manually by using the [Azure Management Portal](http://portal.azure.com), or by using Visual Studio:
+You can register your app manually by using the [Azure Management Portal](https://portal.azure.com), or by using Visual Studio:
 1. To register your app by using Visual Studio, see [Using Visual Studio to register your app and add Office 365 APIs.](https://msdn.microsoft.com/office/office365/HowTo/adding-service-to-your-Visual-Studio-project)
-2. To register your app manually, see [Manually register your app with Azure AD so it can access Office 365 APIs.](https://msdn.microsoft.com/en-us/office/office365/howto/add-common-consent-manually). Here is a summary to register your App manually:
-    - Go to the [Azure Management Portal](http://portal.azure.com)
+2. To register your app manually, see [Manually register your app with Azure AD so it can access Office 365 APIs.](https://msdn.microsoft.com/office/office365/howto/add-common-consent-manually). Here is a summary to register your App manually:
+    - Go to the [Azure Management Portal](https://portal.azure.com)
     - Go to the "Azure Active Directory" option
     - Go to "App Registrations" option
     - Click on the "New application registration" button
@@ -55,7 +55,7 @@ You can register your app manually by using the [Azure Management Portal](http:/
 
 After you've registered your app, Azure AD will generate a client ID for your app. You'll need to use this client ID to get your access token.
 
-When you register your app in the [Azure Management Portal](http://portal.azure.com), you will need to configure details about your application with the following steps:
+When you register your app in the [Azure Management Portal](https://portal.azure.com), you will need to configure details about your application with the following steps:
 
 1. Click "Settings" button
 2. Go to "Required permissions" option
@@ -87,7 +87,7 @@ If you don't have one, you need to create an Office 365 Developer Site. There ar
 * [An MSDN subscription](https://msdn.microsoft.com/subscriptions/manage/default.aspx) - This is available to MSDN subscribers with Visual Studio Ultimate and Visual Studio Premium.
 * [An existing Office 365 subscription](https://msdn.microsoft.com/library/2ec857d5-dc6f-4cf6-ba45-adc845ef2a25%28Office.15%29.aspx) - You can use an existing Office 365 subscription, which can be any of the following: Office 365 Midsize Business, Office 365 Enterprise, Office 365 Education, Office 365 Government.
 * [Free O365 trial](https://portal.office.com/Signup?OfferId=6881A1CB-F4EB-4db3-9F18-388898DAF510&DL=DEVELOPERPACK&ali=1) - You can start with a free 30-day trial, or buy an Office 365 developer subscription.
-* [Free O365 Developer](http://dev.office.com/devprogram) - Or Get a One year free Office 365 Developer account
+* [Free O365 Developer](https://dev.office.com/devprogram) - Or Get a One year free Office 365 Developer account
 
 ## Syntax
 
@@ -354,7 +354,7 @@ End If
 
 ## Sample Project
 
-[MicrosoftGraph Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Microsoft%20Graph%20Service). You can [see this in action](uwpct://Services?sample=Microsoft%20Graph%20Service) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[MicrosoftGraph Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Microsoft%20Graph%20Service). You can [see this in action](uwpct://Services?sample=Microsoft%20Graph%20Service) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 

--- a/docs/services/MicrosoftTranslator.md
+++ b/docs/services/MicrosoftTranslator.md
@@ -11,7 +11,7 @@ dev_langs:
 # Microsoft Translator Service
 
 > [!WARNING]
-> (This API will be removed in the future. Please refer to the [Microsoft Translator](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/) documentation instead.)
+> (This API will be removed in the future. Please refer to the [Microsoft Translator](https://docs.microsoft.com/azure/cognitive-services/translator/) documentation instead.)
 
 The **Microsoft Translator Service** allows you to translate text to various supported languages.
 
@@ -61,7 +61,7 @@ Dim translatedText = translationResult.Translation.Text
 
 ## Sample Project
 
-[Microsoft Translator Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Microsoft%20Translator%20Service). You can [see this in action](uwpct://Services?sample=Microsoft%20Translator%20Service) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[Microsoft Translator Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Microsoft%20Translator%20Service). You can [see this in action](uwpct://Services?sample=Microsoft%20Translator%20Service) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 

--- a/docs/services/MicrosoftTranslator.md
+++ b/docs/services/MicrosoftTranslator.md
@@ -10,6 +10,9 @@ dev_langs:
 
 # Microsoft Translator Service
 
+> [!WARNING]
+> (This API will be removed in the future. Please refer to the [Microsoft Translator](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/) documentation instead.)
+
 The **Microsoft Translator Service** allows you to translate text to various supported languages.
 
 > [!div class="nextstepaction"]
@@ -17,7 +20,7 @@ The **Microsoft Translator Service** allows you to translate text to various sup
 
 ## Set up Microsoft Translator Service
 
-[Signup for Microsoft Translator Service](https://portal.azure.com/#create/Microsoft.CognitiveServices/apitype/TextTranslation) using your Microsoft Azure subscription account. There is a free trial option for that allows you to translate up to 2,000,000 characters per month.
+[Signup for Microsoft Translator Service](https://ms.portal.azure.com/#create/Microsoft.CognitiveServicesTextTranslation) using your Microsoft Azure subscription account. There is a free trial option for that allows you to translate up to 2,000,000 characters per month.
 
 ## Example Syntax
 

--- a/docs/services/MicrosoftTranslator.md
+++ b/docs/services/MicrosoftTranslator.md
@@ -20,7 +20,8 @@ The **Microsoft Translator Service** allows you to translate text to various sup
 
 ## Set up Microsoft Translator Service
 
-[Signup for Microsoft Translator Service](https://ms.portal.azure.com/#create/Microsoft.CognitiveServicesTextTranslation) using your Microsoft Azure subscription account. There is a free trial option for that allows you to translate up to 2,000,000 characters per month.
+[Signup for Microsoft Translator Service](https://ms.portal.azure.com/#create/Microsoft.CognitiveServicesTextTranslation) using your Microsoft Azure subscription account. There is a free trial option that allows you to translate up to 2,000,000 characters per month.
+
 
 ## Example Syntax
 

--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -85,7 +85,7 @@ Microsoft.Toolkit.Services.OneDrive.OneDriveService.Instance.Initialize(appClien
 ```
 
 ### Defining scopes
-More information on scopes can be found in this document [Authentication scopes](https://docs.microsoft.com/en-us/onedrive/developer/rest-api/getting-started/msa-oauth#authentication-scopes)
+More information on scopes can be found in this document [Authentication scopes](https://docs.microsoft.com/onedrive/developer/rest-api/getting-started/msa-oauth#authentication-scopes)
 
 ```csharp
 // If the user hasn't selected a scope then set it to FilesReadAll

--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -13,7 +13,7 @@ dev_langs:
 > [!WARNING]
 > (This API has been removed. Please use the official [Microsoft Graph SDK](https://github.com/microsoftgraph/msgraph-sdk-dotnet) directly. For the latest guidance on using the Microsoft Graph in the Toolkit start with the [InteractiveProviderBehavior](../graph/providers/InteractiveProviderBehavior.md).)
 
-The **OneDrive** Service provides an easy to use service helper for the [OneDrive Developer Platform](https://docs.microsoft.com/en-us/onedrive/developer/) that uses the [Microsoft Graph](https://developer.microsoft.com/en-us/graph/docs/concepts/overview). The new OneDrive API is REST API that brings together both personal and work accounts in a single authentication model. The OneDrive Service helps you:
+The **OneDrive** Service provides an easy to use service helper for the [OneDrive Developer Platform](https://docs.microsoft.com/onedrive/developer/) that uses the [Microsoft Graph](https://developer.microsoft.com/graph/docs/concepts/overview). The new OneDrive API is REST API that brings together both personal and work accounts in a single authentication model. The OneDrive Service helps you:
 
 * Initialize and authenticate with a common set of objects
 * Access OneDrive, OneDrive for Business, SharePoint document libraries, and Office Groups, to allow your app the flexibility to read and store content in any of these locations with the same code
@@ -55,13 +55,13 @@ You will need to add:
 
 < Capability Name="privateNetworkClientServer" />
 
-to your application manifest to enable AAD authentication. Capabilities in the manifest are described in more detail in this document [Capability](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appxmanifestschema/element-capability)
+to your application manifest to enable AAD authentication. Capabilities in the manifest are described in more detail in this document [Capability](https://docs.microsoft.com/uwp/schemas/appxpackage/appxmanifestschema/element-capability)
 
-Authentication, sign-in and permission scopes are discussed in more detail in this document, [Authorization and sign-in for OneDrive in Microsoft Graph](https://docs.microsoft.com/en-us/onedrive/developer/rest-api/getting-started/graph-oauth)
+Authentication, sign-in and permission scopes are discussed in more detail in this document, [Authorization and sign-in for OneDrive in Microsoft Graph](https://docs.microsoft.com/onedrive/developer/rest-api/getting-started/graph-oauth)
 
 ### Testing access to the OneDrive API
 
-Registering your applicatioin creates an App ID/Client and you can simply paste that into the Client Id field inside of the OneDrive services page.  
+Registering your application creates an App ID/Client and you can simply paste that into the Client Id field inside of the OneDrive services page.  
 
 ## Syntax
 
@@ -304,11 +304,11 @@ End Using
 
 This is because OneDrive's API doesn't offer the same level of collision options (or ConflictBehavior) as the ones provided by _Windows.Storage.CreationCollisionOption_ which is used for file managing. Therefore, when using the method CreateFileAsync with the parameter _OpenIfExists_, it's set to return an ArgumentException from the OneDriveHelper _TransformCollisionOptionToConflictBehavior_ method.
 
-As a workaround, the recommended path is using _CreateCollisionOption.FailIfExists_ within a try/catch statement and opening the file whenever the error is catched, or else, manually checking previously if the file exists.
+As a workaround, the recommended path is using _CreateCollisionOption.FailIfExists_ within a try/catch statement and opening the file whenever the error is caught, or else, manually checking previously if the file exists.
 
 ## Sample Project
 
-[OneDrive Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/OneDrive%20Service). You can [see this in action](uwpct://Services?sample=OneDrive%20Service) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[OneDrive Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/OneDrive%20Service). You can [see this in action](uwpct://Services?sample=OneDrive%20Service) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 

--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -10,6 +10,9 @@ dev_langs:
 
 # OneDrive Service
 
+> [!WARNING]
+> (This API has been removed. Please use the official [Microsoft Graph SDK](https://github.com/microsoftgraph/msgraph-sdk-dotnet) directly. For the latest guidance on using the Microsoft Graph in the Toolkit start with the [InteractiveProviderBehavior](../graph/providers/InteractiveProviderBehavior.md).)
+
 The **OneDrive** Service provides an easy to use service helper for the [OneDrive Developer Platform](https://docs.microsoft.com/en-us/onedrive/developer/) that uses the [Microsoft Graph](https://developer.microsoft.com/en-us/graph/docs/concepts/overview). The new OneDrive API is REST API that brings together both personal and work accounts in a single authentication model. The OneDrive Service helps you:
 
 * Initialize and authenticate with a common set of objects

--- a/docs/services/Twitter.md
+++ b/docs/services/Twitter.md
@@ -15,7 +15,8 @@ dev_langs:
 
 The **Twitter Service** allows users to retrieve or publish data to Twitter.
 
-[Twitter Developer Site](https://dev.twitter.com) is the main content site for all twitter developers.  Visit the [Twitter Apps List](https://apps.twitter.com/) to manage existing apps.
+[Twitter Developer Site](https://dev.twitter.com) is the main content site for all Twitter developers.  Visit the [Twitter Apps List](https://apps.twitter.com/) to manage existing apps.
+
 
 [Create new Twitter App](https://apps.twitter.com/app) can be used to create a new app within the Twitter portal.
 

--- a/docs/services/Twitter.md
+++ b/docs/services/Twitter.md
@@ -10,6 +10,9 @@ dev_langs:
 
 # Twitter Service
 
+> [!WARNING]
+> (This API will be removed in the future.)
+
 The **Twitter Service** allows users to retrieve or publish data to Twitter.
 
 [Twitter Developer Site](https://dev.twitter.com) is the main content site for all twitter developers.  Visit the [Twitter Apps List](https://apps.twitter.com/) to manage existing apps.

--- a/docs/services/Twitter.md
+++ b/docs/services/Twitter.md
@@ -206,7 +206,7 @@ The toolkit has implementations of each of them for UWP. You can find them as Uw
 
 ## Sample Project
 
-[Twitter Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter%20Service). You can [see this in action](uwpct://Services?sample=Twitter%20Service) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[Twitter Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter%20Service). You can [see this in action](uwpct://Services?sample=Twitter%20Service) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 

--- a/docs/services/Weibo.md
+++ b/docs/services/Weibo.md
@@ -10,6 +10,9 @@ dev_langs:
 
 # Weibo Service
 
+> [!WARNING]
+> (This API will be removed in the future.)
+
 The **Weibo Service** allows users to retrieve or publish data to Weibo. Visit [https://open.weibo.com](https://open.weibo.com) to create a new app or manage existing apps.
 
 > [!div class="nextstepaction"]

--- a/docs/services/Weibo.md
+++ b/docs/services/Weibo.md
@@ -96,7 +96,7 @@ Await WeiboService.Instance.PostStatusAsync(StatusText.Text, stream)
 
 ## Sample Project
 
-[Weibo Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Weibo%20Service). You can [see this in action](uwpct://Services?sample=Weibo%20Service) in the [Windows Community Toolkit Sample App](http://aka.ms/uwptoolkitapp).
+[Weibo Service Sample Page Source](https://github.com/Microsoft/WindowsCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Weibo%20Service). You can [see this in action](uwpct://Services?sample=Weibo%20Service) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -206,7 +206,8 @@
 ### [Facebook Service](services/Facebook.md)
 ### [LinkedIn Service](services/Linkedin.md)
 ### [Microsoft Graph Service](services/MicrosoftGraph.md)
-#### [GraphLogin (WinForms)](services/GraphLogin.md)
+### [GraphLogin (WinForms)](services/GraphLogin.md)
+
 ### [Microsoft Translator Service](services/MicrosoftTranslator.md)
 ### [OneDrive Service](services/OneDrive.md)
 ### [Twitter Service](services/Twitter.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -146,9 +146,6 @@
 ## [Converters](helpers/Converters.md)
 ## [DeepLinkParser](helpers/DeepLinkParsers.md)
 ## [DispatcherHelper](helpers/DispatcherHelper.md)
-## [HttpHelper](helpers/HttpHelper.md)
-## [HttpHelperRequest](helpers/HttpHelperRequest.md)
-## [HttpHelperResponse](helpers/HttpHelperResponse.md)
 ## [ImageCache](helpers/ImageCache.md)
 ## [IncrementalLoadingCollection](helpers/IncrementalLoadingCollection.md)
 ## [NetworkHelper](helpers/NetworkHelper.md)
@@ -163,19 +160,6 @@
 ## [Triggers](helpers/Triggers.md)
 ## [WeakEventListener](helpers/WeakEventListener.md)
 ## [ViewportBehavior](helpers/ViewportBehavior.md)
-
-# Services
-## [Facebook Service](services/Facebook.md)
-## [LinkedIn Service](services/Linkedin.md)
-## [Microsoft Graph Service](services/MicrosoftGraph.md)
-### [GraphLogin (WinForms)](services/GraphLogin.md)
-## [Microsoft Translator Service](services/MicrosoftTranslator.md)
-## [OneDrive Service](services/OneDrive.md)
-## [Twitter Service](services/Twitter.md)
-## [Weibo Service](services/Weibo.md)
-
-# Parsers
-## [MarkdownParser](parsers/MarkdownParser.md)
 
 # High performance
 ## [Introduction](high-performance/Introduction.md)
@@ -203,6 +187,10 @@
 ### [HamburgerMenu](archive/HamburgerMenu.md)
 ### [PullToRefreshListView](archive/PullToRefreshListview.md)
 ### [SlidableListItem](archive/SlidableListItem.md)
+## Helpers
+### [HttpHelper](helpers/HttpHelper.md)
+### [HttpHelperRequest](helpers/HttpHelperRequest.md)
+### [HttpHelperResponse](helpers/HttpHelperResponse.md)
 ## Microsoft Graph Controls
 ### [AadLogin](archive/graph/AadLogin.md)
 ### [PeoplePicker](archive/graph/PeoplePicker.md)
@@ -211,6 +199,15 @@
 ### [ProfileCard](archive/graph/ProfileCard.md)
 ### [SharePointFileList](archive/graph/SharePointFileList.md)
 ## Parsers
+### [MarkdownParser](parsers/MarkdownParser.md)
 ### [RSSParser](parsers/RSSParser.md)
 ## Services
 ### [Bing Service](archive/Bing.md)
+### [Facebook Service](services/Facebook.md)
+### [LinkedIn Service](services/Linkedin.md)
+### [Microsoft Graph Service](services/MicrosoftGraph.md)
+#### [GraphLogin (WinForms)](services/GraphLogin.md)
+### [Microsoft Translator Service](services/MicrosoftTranslator.md)
+### [OneDrive Service](services/OneDrive.md)
+### [Twitter Service](services/Twitter.md)
+### [Weibo Service](services/Weibo.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -176,7 +176,6 @@
 
 # Parsers
 ## [MarkdownParser](parsers/MarkdownParser.md)
-## [RSSParser](parsers/RSSParser.md)
 
 # High performance
 ## [Introduction](high-performance/Introduction.md)
@@ -211,5 +210,7 @@
 ### [PowerBIEmbedded](archive/graph/PowerBIEmbedded.md)
 ### [ProfileCard](archive/graph/ProfileCard.md)
 ### [SharePointFileList](archive/graph/SharePointFileList.md)
+## Parsers
+### [RSSParser](parsers/RSSParser.md)
 ## Services
 ### [Bing Service](archive/Bing.md)


### PR DESCRIPTION
## Fixes #378
## Docs for Toolkit PR [#3435](https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/3435)

## What changes to the docs does this PR provide?
Creates a migration guide for RssParser to the .NET API instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Correctly picked the right branch to base the change off (`master` for new features, `live` for typos/improvements)
- [x] Ran against a spell and grammar checker 
- [x] Contains **NO** breaking changes

## Other information
Tested both C# and VB versions of replacement code. 🙂 FYI @mrlacey