### PR TITLE
Improved warning about Ref<T>

### DIFF
--- a/docs/high-performance/Ref.md
+++ b/docs/high-performance/Ref.md
@@ -61,7 +61,7 @@ Console.WriteLine(number); // Prints 43!
 ```
 
 > [!WARNING]
-> This type comes with a few caveats and should be used carefully, as it can lead to runtime crashes if a `Ref<T>` instance is created with an invalid reference. In particular, you should only create a `Ref<T>` instance pointing to values that have a lifetime that is greater than that of the `Ref<T>` in use. Consider the following snippet:
+> This type comes with a few caveats and should be used very carefully. On .NET Core runtimes, any use of `Ref<T>` may cause intermittent crashes or data corruptions, as `Ref<T>` is using internal implementation details of the .NET runtime in an unsupported way. Also, using this type can lead to runtime crashes if a `Ref<T>` instance is created with an invalid reference. In particular, you should only create a `Ref<T>` instance pointing to values that have a lifetime that is greater than that of the `Ref<T>` in use. Consider the following snippet:
 
 ```csharp
 public static ref int GetDummyReference()


### PR DESCRIPTION
## Docs for Toolkit PR [\#3367](https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/3367) <!-- Link to relevant issue or Feature PR # of the Windows Community Toolkit repo which will create a reference to the associated issue and PR once it is created, remove if not tied to an issue or feature -->

## What changes to the docs does this PR provide?
<!-- Please describe the updated information in detail -->
Extra warning about the `Ref<T>` type on .NET Core runtimes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Correctly picked the right branch to base the change off (`master` for new features, `live` for typos/improvements)
- [X] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/.template.md)
- [X] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/toc.md)
- [X] Ran against a spell and grammar checker 
- [X] Contains **NO** breaking changes