### PR TITLE
Links: Windows Community Toolkit (2021-01) - 1

### DIFF
--- a/docs/extensions/HyperlinkExtensions.md
+++ b/docs/extensions/HyperlinkExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # HyperlinkExtensions
 
-The [HyperlinkExtension](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.hyperlink) allows for a Hyperlink element to invoke the execute method on a bound [ICommand](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Input.ICommand) instance when clicked.
+The [HyperlinkExtension](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.hyperlink) allows for a Hyperlink element to invoke the execute method on a bound [ICommand](/uwp/api/Windows.UI.Xaml.Input.ICommand) instance when clicked.
 
 ## Example
 
@@ -39,4 +39,3 @@ The [HyperlinkExtension](https://docs.microsoft.com/dotnet/api/microsoft.toolkit
 ## API
 
 * [Hyperlink source code](https://github.com/Microsoft/WindowsCommunityToolkit//blob/master/Microsoft.Toolkit.Uwp.UI/Extensions/Hyperlink)
-

--- a/docs/extensions/IconMarkupExtensions.md
+++ b/docs/extensions/IconMarkupExtensions.md
@@ -7,10 +7,10 @@ keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, nullable bool, de
 
 # IconMarkupExtensions
 
-The icon extensions are a group of markup extensions meant to simplify the creation of various icon types (specifically [`BitmapIcon`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls.BitmapIcon), [`BitmapIconSource`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls.BitmapIconSource), [`FontIcon`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls.FontIcon), [`FontIconSource`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls.FontIconSource), [`SymbolIcon`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls.SymbolIcon), and [`SymbolIconSource`](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls.SymbolIconSource)) used across a variety of XAML controls. Using these extensions doesn't enable new capabilities per se, but it greatly simplifies the XAML syntax needed to create instances of these icon types. There are six such extensions available at the moment: `BitmapIconExtension`, `BitmapIconSourceExtension`, `FontIconExtension`, `FontIconSourceExtension`, `SymbolIconExtension` and `SymbolIconSourceExtension`.
+The icon extensions are a group of markup extensions meant to simplify the creation of various icon types (specifically [`BitmapIcon`](/uwp/api/Windows.UI.Xaml.Controls.BitmapIcon), [`BitmapIconSource`](/uwp/api/Windows.UI.Xaml.Controls.BitmapIconSource), [`FontIcon`](/uwp/api/Windows.UI.Xaml.Controls.FontIcon), [`FontIconSource`](/uwp/api/Windows.UI.Xaml.Controls.FontIconSource), [`SymbolIcon`](/uwp/api/Windows.UI.Xaml.Controls.SymbolIcon), and [`SymbolIconSource`](/uwp/api/Windows.UI.Xaml.Controls.SymbolIconSource)) used across a variety of XAML controls. Using these extensions doesn't enable new capabilities per se, but it greatly simplifies the XAML syntax needed to create instances of these icon types. There are six such extensions available at the moment: `BitmapIconExtension`, `BitmapIconSourceExtension`, `FontIconExtension`, `FontIconSourceExtension`, `SymbolIconExtension` and `SymbolIconSourceExtension`.
 
 ## BitmapIcon
-The [BitmapIcon markup extension](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.bitmapiconextension) is similar in structure to the two previous extensions, but it produces `BitmapIcon` instances instead of font-based icons.
+The [BitmapIcon markup extension](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.bitmapiconextension) is similar in structure to the two previous extensions, but it produces `BitmapIcon` instances instead of font-based icons.
 
 ### Syntax
 
@@ -41,7 +41,7 @@ The [BitmapIcon markup extension](https://docs.microsoft.com/en-us/dotnet/api/mi
 | ShowAsMonochrome | bool | Indicates whether to display the icon as monochrome. |
 
 ## BitmapIconSource
-The [BitmapIconSource markup extension](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.bitmapiconsourceextension) mirrors the `BitmapIconExtension` type, with the only difference being that it returns a [`BitmapIconSource`](https://docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.bitmapiconsource) instance..
+The [BitmapIconSource markup extension](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.bitmapiconsourceextension) mirrors the `BitmapIconExtension` type, with the only difference being that it returns a [`BitmapIconSource`](/uwp/api/microsoft.ui.xaml.controls.bitmapiconsource) instance..
 
 ### Syntax
 
@@ -61,7 +61,7 @@ The [BitmapIconSource markup extension](https://docs.microsoft.com/en-us/dotnet/
 | ShowAsMonochrome | bool | Indicates whether to display the icon as monochrome. |
 
 ## FontIcon
-The [FontIcon markup extension](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.fonticonextension) provides the ability to create `FontIcon` instances from XAML with a more compact representation than by explicitly creating a new `FontIcon` object to assign to the target property. The property also maps all the available `FontIcon` properties, so the two APIs expose the same set of customization options, just through a different XAML syntax.
+The [FontIcon markup extension](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.fonticonextension) provides the ability to create `FontIcon` instances from XAML with a more compact representation than by explicitly creating a new `FontIcon` object to assign to the target property. The property also maps all the available `FontIcon` properties, so the two APIs expose the same set of customization options, just through a different XAML syntax.
 
 ### Syntax
 
@@ -95,7 +95,7 @@ The [FontIcon markup extension](https://docs.microsoft.com/en-us/dotnet/api/micr
 | MirroredWhenRightToLeft | bool | Indicates whether the icon is mirrored when the flow direction is right to left. |
 
 ## FontIconSource
-The [FontIconSource markup extension](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.fonticonsourceextension) mirrors the `FontIconExtension` type, but producing `FontIconSource` instances instead of `FontIcon`.
+The [FontIconSource markup extension](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.fonticonsourceextension) mirrors the `FontIconExtension` type, but producing `FontIconSource` instances instead of `FontIcon`.
 
 ### Syntax
 
@@ -129,7 +129,7 @@ The [FontIconSource markup extension](https://docs.microsoft.com/en-us/dotnet/ap
 | MirroredWhenRightToLeft | bool | Indicates whether the icon is mirrored when the flow direction is right to left. |
 
 ## SymbolIcon
-The [SymbolIcon markup extension](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.symboliconextension) mirrors the `FontIcon` markup extension, with the main difference being that it uses a [`Symbol`](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.symbol) value to specify the icon. All the other properties from `FontIconExtension` are available, with the exception of the font family, which is always set to "Segoe MDL2 Assets".
+The [SymbolIcon markup extension](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.symboliconextension) mirrors the `FontIcon` markup extension, with the main difference being that it uses a [`Symbol`](/uwp/api/windows.ui.xaml.controls.symbol) value to specify the icon. All the other properties from `FontIconExtension` are available, with the exception of the font family, which is always set to "Segoe MDL2 Assets".
 
 ### Syntax
 
@@ -165,7 +165,7 @@ The [SymbolIcon markup extension](https://docs.microsoft.com/en-us/dotnet/api/mi
 > The `SymbolIconExtension` actually returns a `FontIcon` value instead of a `SymbolIcon` one. This is done to include the additional properties (eg. `FontSize`, `FontWeight`, etc.) that would otherwise not have been available. When those are not modified, the look of the resulting icon will still be the same as the one that would've resulted from the use of a `SymbolIcon` instance.
 
 ## SymbolIconSource
-The [SymbolIconSource markup extension](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.symboliconsourceextension) is an alternative for `FontIconSourceExtension` that takes a `Symbol` value instead of a text, and displays the icon with the "Segoe MDL2 Assets". It's equivalent to the `SymbolIconExtension` type, except for the fact that it returns a [`FontIconSource`](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.fonticonsource) instance.
+The [SymbolIconSource markup extension](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.symboliconsourceextension) is an alternative for `FontIconSourceExtension` that takes a `Symbol` value instead of a text, and displays the icon with the "Segoe MDL2 Assets". It's equivalent to the `SymbolIconExtension` type, except for the fact that it returns a [`FontIconSource`](/uwp/api/windows.ui.xaml.controls.fonticonsource) instance.
 
 ### Syntax
 
@@ -210,4 +210,4 @@ All the values returned by these markup extensions belong to the `Windows.UI.Xam
 
 ## Related Topics
 
-- [MarkupExtension Class](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.markup.markupextension)
+- [MarkupExtension Class](/uwp/api/windows.ui.xaml.markup.markupextension)

--- a/docs/extensions/ListViewBase.md
+++ b/docs/extensions/ListViewBase.md
@@ -8,13 +8,13 @@ keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, ListViewBase, ext
 
 # ListViewBase extentions
 
-ListViewBase extensions provide a lightweight way to extend every control that inherits the <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.listviewbase" target="_blank">ListViewBase</a> class with attached properties.
+ListViewBase extensions provide a lightweight way to extend every control that inherits the <a href="/uwp/api/windows.ui.xaml.controls.listviewbase" target="_blank">ListViewBase</a> class with attached properties.
 
 ## AlternateColor
 
 The AlternateColor property provides a way to assign a background color to every other item.
 
-> The <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging" target="_blank">ContainerContentChanging</a> event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
+> The <a href="/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging" target="_blank">ContainerContentChanging</a> event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
 
 ### Example
 
@@ -26,9 +26,9 @@ The AlternateColor property provides a way to assign a background color to every
 
 ## AlternateItemTemplate
 
-The AlternateItemTemplate property provides a way to assign an alternate <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.datatemplate" target="_blank">datatemplate</a> to every other item. It is also possible to combine with the AlternateColor property.
+The AlternateItemTemplate property provides a way to assign an alternate <a href="/uwp/api/windows.ui.xaml.datatemplate" target="_blank">datatemplate</a> to every other item. It is also possible to combine with the AlternateColor property.
 
-> The <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging" target="_blank">ContainerContentChanging</a> event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
+> The <a href="/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging" target="_blank">ContainerContentChanging</a> event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
 
 ### Example
 
@@ -53,7 +53,7 @@ The AlternateItemTemplate property provides a way to assign an alternate <a href
 
 The StretchItemContainerDirection property provides a way to stretch the ItemContainer in horizontal, vertical or both ways. Possible values for this property are **Horizontal**, **Vertical** and **Both**.
 
-> The <a href="https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging" target="_blank">ContainerContentChanging</a> event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
+> The <a href="/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging" target="_blank">ContainerContentChanging</a> event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
 
 ### Example
 
@@ -65,11 +65,10 @@ The StretchItemContainerDirection property provides a way to stretch the ItemCon
 
 ## Requirements (Windows 10 Device Family)
 
-| [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.14393.0 or higher |
+| [Device family](/windows/uwp/get-started/universal-application-platform-guide) | Universal, 10.0.14393.0 or higher |
 | --- | --- |
 | Namespace | Microsoft.Toolkit.Uwp.UI.Extensions |
 
 ## API
 
 * [ListViewBase source code](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase)
-

--- a/docs/extensions/ListViewExtensions.md
+++ b/docs/extensions/ListViewExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # ListViewExtensions
 
-[ListViewExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.listviewextensions) provide a lightweight way to extend every control that inherits the [ListViewBase](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls.ListViewBase) class with attached properties.
+[ListViewExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.listviewextensions) provide a lightweight way to extend every control that inherits the [ListViewBase](/uwp/api/Windows.UI.Xaml.Controls.ListViewBase) class with attached properties.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Extensions?sample=ListViewExtensions)
@@ -17,7 +17,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 The AlternateColor property provides a way to assign a background color to every other item.
 
 > [!WARNING]
-> The [ContainerContentChanging](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging) event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
+> The [ContainerContentChanging](/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging) event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid. 
 
 ### Syntax
 
@@ -38,10 +38,10 @@ The AlternateColor property provides a way to assign a background color to every
 
 ## AlternateItemTemplate extentions
 
-The AlternateItemTemplate property provides a way to assign an alternate [datatemplate](https://docs.microsoft.com/uwp/api/windows.ui.xaml.datatemplate) to every other item. It is also possible to combine with the AlternateColor property.
+The AlternateItemTemplate property provides a way to assign an alternate [datatemplate](/uwp/api/windows.ui.xaml.datatemplate) to every other item. It is also possible to combine with the AlternateColor property.
 
 > [!WARNING]
-> The [ContainerContentChanging](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging) event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid.
+> The [ContainerContentChanging](/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging) event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than ItemsStackPanel or ItemsWrapGrid.
 
 ### Syntax
 
@@ -73,10 +73,10 @@ The AlternateItemTemplate property provides a way to assign an alternate [datate
 
 ## Command extentions
 
-ListViewExtensions provides extension method that allow attaching [ICommand](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Input.ICommand) to handle ListViewBase Item interaction by means of [ItemClick](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ItemClick) event.
+ListViewExtensions provides extension method that allow attaching [ICommand](/uwp/api/Windows.UI.Xaml.Input.ICommand) to handle ListViewBase Item interaction by means of [ItemClick](/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ItemClick) event.
 
 > [!IMPORTANT]
-> ListViewBase [IsItemClickEnabled](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_IsItemClickEnabled) must be set to `true`
+> ListViewBase [IsItemClickEnabled](/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_IsItemClickEnabled) must be set to `true`
 
 ### Syntax
 
@@ -102,7 +102,7 @@ ListViewExtensions provides extension method that allow attaching [ICommand](htt
 The StretchItemContainerDirection property provides a way to stretch the ItemContainer in horizontal, vertical or both ways. Possible values for this property are *Horizontal*, *Vertical* and *Both*.
 
 > [!WARNING]
-> The [ContainerContentChanging](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging) event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than `ItemsStackPanel` or `ItemsWrapGrid`.
+> The [ContainerContentChanging](/uwp/api/windows.ui.xaml.controls.listviewbase#Windows_UI_Xaml_Controls_ListViewBase_ContainerContentChanging) event used for this extension to work, will not be raised when the ItemsPanel is replaced with another type of panel than `ItemsStackPanel` or `ItemsWrapGrid`.
 
 ### Syntax
 
@@ -119,7 +119,7 @@ The StretchItemContainerDirection property provides a way to stretch the ItemCon
 
 | Property | Type | Description |
 | --| -- | -- |
-| StretchItemContainerDirection | [ListViewBase.StretchDirection](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.listviewbase.stretchdirection) | Attached `DependencyProperty` for setting the container content stretch direction on the `ListViewBase` |
+| StretchItemContainerDirection | [ListViewBase.StretchDirection](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.listviewbase.stretchdirection) | Attached `DependencyProperty` for setting the container content stretch direction on the `ListViewBase` |
 
 ## Sample Project
 

--- a/docs/extensions/LogicalTree.md
+++ b/docs/extensions/LogicalTree.md
@@ -10,9 +10,9 @@ dev_langs:
 
 # Logical Tree Extensions
 
-The [LogicalTree](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.logicaltree) extensions provide a collection of extensions methods for UI controls.
+The [LogicalTree](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.logicaltree) extensions provide a collection of extensions methods for UI controls.
 
-It provides [FrameworkElement](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.FrameworkElement) extensions to aid in walking the logical tree of control structures.
+It provides [FrameworkElement](/uwp/api/Windows.UI.Xaml.FrameworkElement) extensions to aid in walking the logical tree of control structures.
 
 This differs from the *Visual Tree* where extra containers and styles can wrap other elements.
 The Logical Tree instead defines how controls are directly connected through construction.
@@ -94,4 +94,4 @@ Dim content = uiElement.GetContentControl()
 
 ## Related Topics
 
-- [VisualTree Extensions](https://docs.microsoft.com/windows/communitytoolkit/extensions/visualtree)
+- [VisualTree Extensions](./visualtree.md)

--- a/docs/extensions/MatrixExtensions.md
+++ b/docs/extensions/MatrixExtensions.md
@@ -8,7 +8,7 @@ dev_langs:
 ---
 
 # Matrix Extensions
-The [Matrix Extensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.matrixextensions) provide methods to transform a [Matrix](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.Matrix) (Rotate, Scale, Translate, etc...).  These are a similar subset of methods originally provided in the [System.Windows.Media.Matrix](https://msdn.microsoft.com/en-us/library/system.windows.media.matrix(v=vs.110).aspx) class.
+The [Matrix Extensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.matrixextensions) provide methods to transform a [Matrix](/uwp/api/Windows.UI.Xaml.Media.Matrix) (Rotate, Scale, Translate, etc...).  These are a similar subset of methods originally provided in the [System.Windows.Media.Matrix](/dotnet/api/system.windows.media.matrix) class.
 
 ## Methods
 
@@ -25,7 +25,7 @@ The [Matrix Extensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.
 
 ## Requirements (Windows 10 Device Family)
 
-| [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.16299.0 or higher |
+| [Device family](/windows/uwp/get-started/universal-application-platform-guide) | Universal, 10.0.16299.0 or higher |
 | --- | --- |
 | Namespace | Microsoft.Toolkit.Uwp.UI |
 | NuGet package | [Microsoft.Toolkit.Uwp.UI](https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.UI/) |
@@ -36,5 +36,5 @@ The [Matrix Extensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.
 
 ## Related Topics
 
-- [Windows.UI.Xaml.Media.Matrix](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.Matrix)
-- [System.Windows.Media.Matrix](https://msdn.microsoft.com/en-us/library/system.windows.media.matrix(v=vs.110).aspx)
+- [Windows.UI.Xaml.Media.Matrix](/uwp/api/Windows.UI.Xaml.Media.Matrix)
+- [System.Windows.Media.Matrix](/dotnet/api/system.windows.media.matrix)

--- a/docs/extensions/MatrixHelperEx.md
+++ b/docs/extensions/MatrixHelperEx.md
@@ -8,7 +8,7 @@ dev_langs:
 ---
 
 # MatrixHelperEx
-[MatrixHelperEx](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.matrixhelperex) provides extra methods for various matrix operations.
+[MatrixHelperEx](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.matrixhelperex) provides extra methods for various matrix operations.
 
 ## Methods
 
@@ -20,7 +20,7 @@ dev_langs:
 
 ## Requirements (Windows 10 Device Family)
 
-| [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.16299.0 or higher |
+| [Device family](/windows/uwp/get-started/universal-application-platform-guide) | Universal, 10.0.16299.0 or higher |
 | --- | --- |
 | Namespace | Microsoft.Toolkit.Uwp.UI |
 | NuGet package | [Microsoft.Toolkit.Uwp.UI](https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.UI/) |
@@ -31,7 +31,7 @@ dev_langs:
 
 ## Related Topics
 
-- [Windows.UI.Xaml.Media.Matrix](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.Matrix)
-- [Windows.Foundation.Rect](https://docs.microsoft.com/en-us/uwp/api/Windows.Foundation.Rect)
-- [System.Windows.Media.Matrix](https://msdn.microsoft.com/en-us/library/system.windows.media.matrix(v=vs.110).aspx)
-- [System.Windows.Rect](https://msdn.microsoft.com/en-us/library/system.windows.rect(v=vs.110).aspx)
+- [Windows.UI.Xaml.Media.Matrix](/uwp/api/Windows.UI.Xaml.Media.Matrix)
+- [Windows.Foundation.Rect](/uwp/api/Windows.Foundation.Rect)
+- [System.Windows.Media.Matrix](/dotnet/api/system.windows.media.matrix)
+- [System.Windows.Rect](/dotnet/api/system.windows.rect)

--- a/docs/extensions/MouseCursor.md
+++ b/docs/extensions/MouseCursor.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # Mouse.Cursor attached property
 
-The [Mouse.Cursor attached property](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.mouse.cursor) enables you to easily change the mouse cursor over specific Framework elements.
+The [Mouse.Cursor attached property](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.mouse.cursor) enables you to easily change the mouse cursor over specific Framework elements.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Extensions?sample=Mouse)
@@ -25,7 +25,7 @@ The [Mouse.Cursor attached property](https://docs.microsoft.com/dotnet/api/micro
 
 | Property | Type | Description |
 | -- | -- | -- |
-| Mouse.Cursor | [CoreCursorType](https://docs.microsoft.com/uwp/api/Windows.UI.Core.CoreCursorType) | Set cursor type when mouse cursor over a Framework elements |
+| Mouse.Cursor | [CoreCursorType](/uwp/api/Windows.UI.Core.CoreCursorType) | Set cursor type when mouse cursor over a Framework elements |
 
 ## Example
 
@@ -46,11 +46,11 @@ Here is a example of setting Mouse.Cursor
 ```
 
 > [!NOTE]
-> Even though Microsoft recommends in [UWP Design guidelines](https://docs.microsoft.com/windows/uwp/input-and-devices/mouse-interactions#cursors) hover effects instead of custom cursors over interactive elements, custom cursors can be useful in some specific scenarios.
+> Even though Microsoft recommends in [UWP Design guidelines](/windows/uwp/input-and-devices/mouse-interactions#cursors) hover effects instead of custom cursors over interactive elements, custom cursors can be useful in some specific scenarios.
 
 ## Limitations
 
-Because the UWP framework does not support metadata on Attached Properties, specifically the [FrameworkPropertyMetadata.Inherits](https://msdn.microsoft.com/library/ms557301%28v=vs.110%29.aspx) flag, the Mouse.Cursor might not work properly in some very specific XAML layout scenarios when combining nested FrameworkElements with different Mouse.Cursor values set on them.
+Because the UWP framework does not support metadata on Attached Properties, specifically the [FrameworkPropertyMetadata.Inherits](/dotnet/api/system.windows.frameworkpropertymetadata.-ctor) flag, the Mouse.Cursor might not work properly in some very specific XAML layout scenarios when combining nested FrameworkElements with different Mouse.Cursor values set on them.
 
 ## Sample Project
 

--- a/docs/extensions/NullableBoolMarkup.md
+++ b/docs/extensions/NullableBoolMarkup.md
@@ -6,7 +6,7 @@ keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, nullable bool, de
 ---
 
 # NullableBool Markup Extension
-The [NullableBool Markup Extension](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.nullablebool) provides the ability to set nullable boolean dependency properties in XAML markup.  These types of properties can normally be bound to, but can't be explicitly set to a specific value.  This extension provides that capability.
+The [NullableBool Markup Extension](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.nullablebool) provides the ability to set nullable boolean dependency properties in XAML markup.  These types of properties can normally be bound to, but can't be explicitly set to a specific value.  This extension provides that capability.
 
 ## Syntax
 
@@ -57,4 +57,4 @@ The [NullableBool Markup Extension](https://docs.microsoft.com/en-us/dotnet/api/
 
 ## Related Topics
 
-- [MarkupExtension Class](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.markup.markupextension)
+- [MarkupExtension Class](/uwp/api/windows.ui.xaml.markup.markupextension)

--- a/docs/extensions/OnDeviceMarkup.md
+++ b/docs/extensions/OnDeviceMarkup.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, device family, ma
 
 # OnDevice Markup Extension
 
-The [OnDevice Markup Extension](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.ondevice) allows you to customize UI appearance on a per-DeviceFamily basis. It is inspired on the [OnPlatform](https://github.com/xamarin/Xamarin.Forms/issues/2608) markup extensions from Xamarin.Forms 3.2
+The [OnDevice Markup Extension](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.ondevice) allows you to customize UI appearance on a per-DeviceFamily basis. It is inspired on the [OnPlatform](https://github.com/xamarin/Xamarin.Forms/issues/2608) markup extensions from Xamarin.Forms 3.2
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Extensions?sample=OnDevice)
@@ -47,5 +47,5 @@ The [OnDevice Markup Extension](https://docs.microsoft.com/en-us/dotnet/api/micr
 
 ## Related Topics
 
-* [MarkupExtension Class](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.markup.markupextension)
-* [SystemInformation.DeviceFamily Property](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.helpers.systeminformation.devicefamily)
+* [MarkupExtension Class](/uwp/api/windows.ui.xaml.markup.markupextension)
+* [SystemInformation.DeviceFamily Property](/dotnet/api/microsoft.toolkit.uwp.helpers.systeminformation.devicefamily)

--- a/docs/extensions/ScrollViewerExtensions.md
+++ b/docs/extensions/ScrollViewerExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # ScrollViewer extensions
 
-The [ScrollViewerExtensions](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.scrollviewerextensions) provide extension methods to improve your ScrollViewer implementation.
+The [ScrollViewerExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.scrollviewerextensions) provide extension methods to improve your ScrollViewer implementation.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Extensions?sample=ScrollViewerExtensions)

--- a/docs/extensions/SurfaceDialTextboxHelper.md
+++ b/docs/extensions/SurfaceDialTextboxHelper.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # SurfaceDialTextbox XAML Property
 
-The [SurfaceDialTextbox XAML Property](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.surfacedialtextbox) adds features from the Surface Dial control to a numeric TextBox. This enables you to modify the content of the TextBox when rotating the Surface Dial (increasing or decreasing the value) and optionally go to the next focus element by tapping the Surface Dial click button.
+The [SurfaceDialTextbox XAML Property](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.surfacedialtextbox) adds features from the Surface Dial control to a numeric TextBox. This enables you to modify the content of the TextBox when rotating the Surface Dial (increasing or decreasing the value) and optionally go to the next focus element by tapping the Surface Dial click button.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Extensions?sample=SurfaceDialTextbox)
@@ -44,7 +44,7 @@ The [SurfaceDialTextbox XAML Property](https://docs.microsoft.com/dotnet/api/mic
 | EnableMinMaxValue | bool | EnableMinMax limits the value in the textbox to your spesificed Min and Max values, see the other properties |
 | EnableTapToNextControl | bool | TapToNext is a feature you can set to automatically try to focus the next focusable element from the Surface Dial enabled TextBox. This is on dy default |
 | ForceMenuItem | bool | If you provide the Controller yourself, set this to true so you won't add new menu items  |
-| Icon | [RadialControllerMenuKnownIcon](https://docs.microsoft.com/uwp/api/windows.ui.input.radialcontrollermenuknownicon) | Set the default icon of the menu item that gets added. A user will most likely not see this. Defaults to the Ruler icon |
+| Icon | [RadialControllerMenuKnownIcon](/uwp/api/windows.ui.input.radialcontrollermenuknownicon) | Set the default icon of the menu item that gets added. A user will most likely not see this. Defaults to the Ruler icon |
 | MaxValue | double | Sets the maxium value the TextBox can have when modifying it using a Surface Dial. Default is 100.0 |
 | MinValue | double | Sets the minimum value the TextBox can have when modifying it using a Surface Dial. Default is -100.0 |
 | StepValue | double | The amount the TextBox will be modified for each rotation step on the Surface Dial |
@@ -56,7 +56,7 @@ The [SurfaceDialTextbox XAML Property](https://docs.microsoft.com/dotnet/api/mic
 
 | Property | Type | Description |
 | -- | -- | -- |
-| static Controller | [RadialController](https://docs.microsoft.com/uwp/api/Windows.UI.Input.RadialController) | Gets or sets the controller for the Surface Dial. The RadialController can be set from your app logic in case you use Surface Dial in other custom cases than on a TextBox. This helper class will do everything for you, but if you want to control the Menu Items and/or wish to use the same Surface Dial insta This is the property for the static controller so you can access it if needed. |
+| static Controller | [RadialController](/uwp/api/Windows.UI.Input.RadialController) | Gets or sets the controller for the Surface Dial. The RadialController can be set from your app logic in case you use Surface Dial in other custom cases than on a TextBox. This helper class will do everything for you, but if you want to control the Menu Items and/or wish to use the same Surface Dial insta This is the property for the static controller so you can access it if needed. |
 | static IsSupported | bool | Gets a value indicating whether this attached proeprty is supported |
 
 ## Sample Project

--- a/docs/extensions/TextBoxMask.md
+++ b/docs/extensions/TextBoxMask.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # TextBoxMask XAML Property
 
-The [TextBoxMask Property](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.textboxmask) allows a user to more easily enter fixed width text in TextBox control where you would like them to enter the data in a certain format, ex: phone number, postal code.
+The [TextBoxMask Property](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.textboxmask) allows a user to more easily enter fixed width text in TextBox control where you would like them to enter the data in a certain format, ex: phone number, postal code.
 
 The developer adds the mask property to prevent end user to enter any other format but the required one, ex postal code aaa-9999
 

--- a/docs/extensions/TextBoxRegex.md
+++ b/docs/extensions/TextBoxRegex.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # TextBoxRegex XAML Property
 
-The [TextBoxRegex Property](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.textboxregex) allows text validation using a regular expression or using built in validation types.
+The [TextBoxRegex Property](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.textboxregex) allows text validation using a regular expression or using built in validation types.
 
 The developer adds a regular expression to validate the TextBox Text against the regular expression throw Regex property or from selecting ValidationType property on the TextBox.
 
@@ -46,8 +46,8 @@ Text box with ValidationType=Email, validation occurs on TextChanged
 | -- | -- | -- |
 | IsValid | bool | Indicates whether the entered text is valid |
 | Regex | string | Set the regular expression that will be used to validate the TextBox |
-| ValidationMode | [ValidationMode](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.textboxregex.validationmode) | Set validation mode. Normal, Forced or Dynamic |
-| ValidationType | [ValidationType](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.textboxregex.validationtype) | Set a built in predefined validation types Email, Decimal, Phone Number, Character or Number |
+| ValidationMode | [ValidationMode](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.textboxregex.validationmode) | Set validation mode. Normal, Forced or Dynamic |
+| ValidationType | [ValidationType](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.textboxregex.validationtype) | Set a built in predefined validation types Email, Decimal, Phone Number, Character or Number |
 
 ## Examples
 

--- a/docs/extensions/TransformExtensions.md
+++ b/docs/extensions/TransformExtensions.md
@@ -8,7 +8,7 @@ dev_langs:
 ---
 
 # Transform Extensions
-The Transform Extensions ([RotateTransformExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.rotatetransformextensions), [ScaleTransformExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.scaletransformextensions), [SkewTransformExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.skewtransformextensions), and [TranslateTransformExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.translatetransformextensions)) provide the ability to retrieve the Matrix of the transform.  This is similar to the `Value` property on the [System.Windows.Media.Transform](https://msdn.microsoft.com/en-us/library/system.windows.media.transform(v=vs.110).aspx) class.
+The Transform Extensions ([RotateTransformExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.rotatetransformextensions), [ScaleTransformExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.scaletransformextensions), [SkewTransformExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.skewtransformextensions), and [TranslateTransformExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.translatetransformextensions)) provide the ability to retrieve the Matrix of the transform.  This is similar to the `Value` property on the [System.Windows.Media.Transform](/dotnet/api/system.windows.media.transform) class.
 
 ## Methods
 
@@ -18,7 +18,7 @@ The Transform Extensions ([RotateTransformExtensions](https://docs.microsoft.com
 
 ## Requirements (Windows 10 Device Family)
 
-| [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.16299.0 or higher |
+| [Device family](/windows/uwp/get-started/universal-application-platform-guide) | Universal, 10.0.16299.0 or higher |
 | --- | --- |
 | Namespace | Microsoft.Toolkit.Uwp.UI |
 | NuGet package | [Microsoft.Toolkit.Uwp.UI](https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.UI/) |
@@ -32,8 +32,8 @@ The Transform Extensions ([RotateTransformExtensions](https://docs.microsoft.com
 
 ## Related Topics
 
-- [Windows.UI.Xaml.Media.RotateTransform](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.RotateTransform)
-- [Windows.UI.Xaml.Media.ScaleTransform](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.ScaleTransform)
-- [Windows.UI.Xaml.Media.SkewTransform](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.SkewTransform)
-- [Windows.UI.Xaml.Media.TranslateTransform](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Media.TranslateTransform)
-- [System.Windows.Media.Transform](https://msdn.microsoft.com/en-us/library/system.windows.media.transform(v=vs.110).aspx)
+- [Windows.UI.Xaml.Media.RotateTransform](/uwp/api/Windows.UI.Xaml.Media.RotateTransform)
+- [Windows.UI.Xaml.Media.ScaleTransform](/uwp/api/Windows.UI.Xaml.Media.ScaleTransform)
+- [Windows.UI.Xaml.Media.SkewTransform](/uwp/api/Windows.UI.Xaml.Media.SkewTransform)
+- [Windows.UI.Xaml.Media.TranslateTransform](/uwp/api/Windows.UI.Xaml.Media.TranslateTransform)
+- [System.Windows.Media.Transform](/dotnet/api/system.windows.media.transform)

--- a/docs/extensions/UIElementExtensions.md
+++ b/docs/extensions/UIElementExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # UIElement Extensions
 
-The [UIElementExtensions](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.extensions.uielementextensions) provide helpers for `UIElement`.
+The [UIElementExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.uielementextensions) provide helpers for `UIElement`.
 
 ## ClipToBounds
 
@@ -42,7 +42,7 @@ The `ClipToBounds` property allows you to indicate whether to clip the content o
 
 ## Requirements (Windows 10 Device Family)
 
-| [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.16299.0 or higher |
+| [Device family](/windows/uwp/get-started/universal-application-platform-guide) | Universal, 10.0.16299.0 or higher |
 | --- | --- |
 | Namespace | Microsoft.Toolkit.Uwp.UI.Extensions |
 | NuGet package | [Microsoft.Toolkit.Uwp.UI](https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.UI/) |
@@ -53,4 +53,4 @@ The `ClipToBounds` property allows you to indicate whether to clip the content o
 
 ## Related Topics
 
-- [UIElement.ClipToBounds Property (WPF)](https://docs.microsoft.com/en-us/dotnet/api/system.windows.uielement.cliptobounds?view=netframework-4.8)
+- [UIElement.ClipToBounds Property (WPF)](/dotnet/api/system.windows.uielement.cliptobounds?view=netframework-4.8)

--- a/docs/extensions/ViewExtensions.md
+++ b/docs/extensions/ViewExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # ViewExtensions
 
-The [ApplicationViewExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.applicationviewextensions), [StatusBarExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.statusbarextensions) & [TitleBarExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.titlebarextensions) provide a declarative way of setting AppView, StatusBar & TitleBar properties from XAML.
+The [ApplicationViewExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.applicationviewextensions), [StatusBarExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.statusbarextensions) & [TitleBarExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.titlebarextensions) provide a declarative way of setting AppView, StatusBar & TitleBar properties from XAML.
 
 
 > [!div class="nextstepaction"]

--- a/docs/extensions/VisualEx.md
+++ b/docs/extensions/VisualEx.md
@@ -8,7 +8,7 @@ keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, Visual, compositi
 
 # Composition Visual Attached Properties
 
-The Composition Visual Attached Properties allow developers to modify common properties of the [object visual](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Composition.Visual) of an element directly in XAML. 
+The Composition Visual Attached Properties allow developers to modify common properties of the [object visual](/uwp/api/Windows.UI.Composition.Visual) of an element directly in XAML. 
 
 ## Example
 
@@ -66,7 +66,7 @@ The point about which rotation or scaling occurs, normalized between the values 
 
 ## Requirements (Windows 10 Device Family)
 
-| [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.16299.0 or higher |
+| [Device family](/windows/uwp/get-started/universal-application-platform-guide) | Universal, 10.0.16299.0 or higher |
 | --- | --- |
 | Namespace | Microsoft.Toolkit.Uwp.UI.Extensions |
 | NuGet package | [Microsoft.Toolkit.Uwp.UI](https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.UI/) |
@@ -74,4 +74,3 @@ The point about which rotation or scaling occurs, normalized between the values 
 ## API
 
 * [Visual extensions source code](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.UI/Extensions/Visual/VisualEx.cs)
-

--- a/docs/extensions/VisualExtensions.md
+++ b/docs/extensions/VisualExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # Composition Visual Attached Properties Extension
 
-The [Composition Visual](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.visualextensions) Attached Properties allow developers to modify common properties of the [object visual](https://docs.microsoft.com/uwp/api/Windows.UI.Composition.Visual) of an element directly in XAML.
+The [Composition Visual](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.visualextensions) Attached Properties allow developers to modify common properties of the [object visual](/uwp/api/Windows.UI.Composition.Visual) of an element directly in XAML.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Extensions?sample=Visual%20Extensions)
@@ -32,16 +32,16 @@ The [Composition Visual](https://docs.microsoft.com/dotnet/api/microsoft.toolkit
 
 | Property | Type | Description |
 | -- | -- | -- |
-| AnchorPoint | [Vector2](https://docs.microsoft.com/uwp/api/Windows.Foundation.Numerics.Vector2) ("0" or "0, 0") | The point on the visual to be positioned at the visual's offset. Value is normalized with respect to the size of the visual |
-| CenterPoint | [Vector3](https://docs.microsoft.com/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The point about which rotation or scaling occurs |
-| Offset | [Vector3](https://docs.microsoft.com/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The offset of the visual relative to its parent or for a root visual the offset relative to the upper-left corner of the windows that hosts the visual |
+| AnchorPoint | [Vector2](/uwp/api/Windows.Foundation.Numerics.Vector2) ("0" or "0, 0") | The point on the visual to be positioned at the visual's offset. Value is normalized with respect to the size of the visual |
+| CenterPoint | [Vector3](/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The point about which rotation or scaling occurs |
+| Offset | [Vector3](/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The offset of the visual relative to its parent or for a root visual the offset relative to the upper-left corner of the windows that hosts the visual |
 | Opacity | double | The opacity of the visual |
 | RotationAngle | double | The rotation angle in radians of the visual |
 | RotationAngleInDegrees | double | The rotation angle of the visual in degrees |
-| RotationAxis | [Vector3](https://docs.microsoft.com/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The axis to rotate the visual around |
-| Scale | [Vector3](https://docs.microsoft.com/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The scale to apply to the visual |
-| Size | [Vector2](https://docs.microsoft.com/uwp/api/Windows.Foundation.Numerics.Vector2) ("0" or "0, 0") | The width and height of the visual |
-| NormalizedCenterPoint | [Vector3](https://docs.microsoft.com/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The point about which rotation or scaling occurs, normalized between the values 0.0 and 1.0 |
+| RotationAxis | [Vector3](/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The axis to rotate the visual around |
+| Scale | [Vector3](/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The scale to apply to the visual |
+| Size | [Vector2](/uwp/api/Windows.Foundation.Numerics.Vector2) ("0" or "0, 0") | The width and height of the visual |
+| NormalizedCenterPoint | [Vector3](/uwp/api/Windows.Foundation.Numerics.Vector3) ("0" or "0, 0, 0") | The point about which rotation or scaling occurs, normalized between the values 0.0 and 1.0 |
 
 ## Requirements
 

--- a/docs/extensions/VisualTree.md
+++ b/docs/extensions/VisualTree.md
@@ -10,9 +10,9 @@ dev_langs:
 
 # Visual Tree Extensions
 
-The [VisualTree extensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.extensions.visualtree) provide a collection of extensions methods for UI controls.
+The [VisualTree extensions](/dotnet/api/microsoft.toolkit.uwp.ui.extensions.visualtree) provide a collection of extensions methods for UI controls.
 
-It provides [DependencyObject](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.DependencyObject) extensions to aid in using the [VisualTreeHelper](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Media.VisualTreeHelper) class. The official [VisualTreeHelper](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Media.VisualTreeHelper) documentation best explains reasons for walking the Visual Tree.
+It provides [DependencyObject](/uwp/api/Windows.UI.Xaml.DependencyObject) extensions to aid in using the [VisualTreeHelper](/uwp/api/Windows.UI.Xaml.Media.VisualTreeHelper) class. The official [VisualTreeHelper](/uwp/api/Windows.UI.Xaml.Media.VisualTreeHelper) documentation best explains reasons for walking the Visual Tree.
 
 ## Syntax
 
@@ -82,4 +82,4 @@ control = uiElement.FindAscendant(Of ScrollViewer)()
 
 ## Related Topics
 
-- [LogicalTree Extensions](https://docs.microsoft.com/en-us/windows/communitytoolkit/extensions/logicaltree)
+- [LogicalTree Extensions](./logicaltree.md)

--- a/docs/extensions/WebView.md
+++ b/docs/extensions/WebView.md
@@ -22,7 +22,7 @@ The **WebViewExtensions** allows attaching HTML content to a WebView.
 
 ## Requirements (Windows 10 Device Family)
 
-| [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.14393.0 or higher |
+| [Device family](/windows/uwp/get-started/universal-application-platform-guide) | Universal, 10.0.14393.0 or higher |
 | --- | --- |
 | Namespace | Microsoft.Toolkit.Uwp.UI.Extensions |
 

--- a/docs/extensions/WebViewExtensions.md
+++ b/docs/extensions/WebViewExtensions.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # WebViewExtensions
 
-The [WebViewExtensions](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.webviewextensions?view=win-comm-toolkit-dotnet-stable) allows attaching HTML content to WebView.
+The [WebViewExtensions](/dotnet/api/microsoft.toolkit.uwp.ui.webviewextensions?view=win-comm-toolkit-dotnet-stable) allows attaching HTML content to WebView.
 
 ## Syntax
 

--- a/docs/gaze/GazeInteractionLibrary.md
+++ b/docs/gaze/GazeInteractionLibrary.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, windows community
 
 # Gaze Interaction Library
 
-Microsoft announced native support for eye tracking in Windows in the [Windows 10 Fall Creators Update](https://blogs.msdn.microsoft.com/accessibility/2017/08/01/from-hack-to-product-microsoft-empowers-people-with-eye-control-for-windows-10/). In the Windows 10 April 2018 update, Microsoft added developer support by releasing [Windows Gaze Input APIs](https://docs.microsoft.com/en-us/uwp/api/windows.devices.input.preview) to build UWP applications that can interact with gaze input and eye trackers.
+Microsoft announced native support for eye tracking in Windows in the [Windows 10 Fall Creators Update](https://blogs.msdn.microsoft.com/accessibility/2017/08/01/from-hack-to-product-microsoft-empowers-people-with-eye-control-for-windows-10/). In the Windows 10 April 2018 update, Microsoft added developer support by releasing [Windows Gaze Input APIs](/uwp/api/windows.devices.input.preview) to build UWP applications that can interact with gaze input and eye trackers.
 
 This Gaze Interaction Library is built on top of the Windows Gaze Input APIs and provides a set of developer helper classes to more easily enable UWP applications to respond to where the user is looking on the screen. This library is intended to abstract away some of the complexities of dealing with the raw stream of gaze input coming from the eye tracking device exposed through the Windows APIs.
 
@@ -208,4 +208,4 @@ private void OnInvokeProgress(object sender, DwellProgressEventArgs e)
 
 ## Related Topics
 
-* [Windows 10 Gaze Input APIs](https://docs.microsoft.com/en-us/uwp/api/windows.devices.input.preview)
+* [Windows 10 Gaze Input APIs](/uwp/api/windows.devices.input.preview)

--- a/docs/graph/controls/LoginButton.md
+++ b/docs/graph/controls/LoginButton.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # LoginButton XAML Control
 
-The [LoginButton](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.graph.controls.loginbutton) is both a button and flyout control to facilitate Microsoft identity platform authentication. It provides two states:
+The [LoginButton](/dotnet/api/microsoft.toolkit.graph.controls.loginbutton) is both a button and flyout control to facilitate Microsoft identity platform authentication. It provides two states:
 
 * When the user is not signed in, the control is a simple button to initiate the sign in process.
 * When the user is signed in, the control displays the current signed in user name, profile image, and email. When clicked, a flyout is opened with a command to sign out.
@@ -61,5 +61,5 @@ The [LoginButton](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.graph.
 
 ## Related Topics
 
-* [User Graph API](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-beta)
-* [MGT Login Component](https://docs.microsoft.com/graph/toolkit/components/login)
+* [User Graph API](/graph/api/resources/user?view=graph-rest-beta)
+* [MGT Login Component](/graph/toolkit/components/login)

--- a/docs/graph/controls/PeoplePicker.md
+++ b/docs/graph/controls/PeoplePicker.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # PeoplePicker XAML Control
 
-The [PeoplePicker](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.graph.controls.peoplepicker) searches for people and renders the list of results from Microsoft Graph. By default, the component will search across all people.
+The [PeoplePicker](/dotnet/api/microsoft.toolkit.graph.controls.peoplepicker) searches for people and renders the list of results from Microsoft Graph. By default, the component will search across all people.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://controls?sample=PeoplePicker)
@@ -48,5 +48,5 @@ The [PeoplePicker](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.graph
 
 ## Related Topics
 
-* [Person Graph API](https://docs.microsoft.com/en-us/graph/api/resources/person?view=graph-rest-beta)
-* [MGT PeoplePicker Component](https://docs.microsoft.com/graph/toolkit/components/people-picker)
+* [Person Graph API](/graph/api/resources/person?view=graph-rest-beta)
+* [MGT PeoplePicker Component](/graph/toolkit/components/people-picker)

--- a/docs/graph/controls/PersonView.md
+++ b/docs/graph/controls/PersonView.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # PersonView XAML Control
 
-The [PersonView](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.graph.controls.personview) is used to display a person or contact by using their photo, name, and/or email address.
+The [PersonView](/dotnet/api/microsoft.toolkit.graph.controls.personview) is used to display a person or contact by using their photo, name, and/or email address.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://controls?sample=PersonView)
@@ -54,5 +54,5 @@ The [PersonView](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.graph.c
 
 ## Related Topics
 
-* [Person Graph API](https://docs.microsoft.com/en-us/graph/api/resources/person?view=graph-rest-beta)
-* [MGT Person Component](https://docs.microsoft.com/graph/toolkit/components/person)
+* [Person Graph API](/graph/api/resources/person?view=graph-rest-beta)
+* [MGT Person Component](/graph/toolkit/components/person)

--- a/docs/graph/providers/InteractiveProviderBehavior.md
+++ b/docs/graph/providers/InteractiveProviderBehavior.md
@@ -10,7 +10,7 @@ dev_langs:
 # InteractiveProviderBehavior XAML Behavior
 
 <!-- Describe your control -->
-The [InteractiveProviderBehavior](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.graph.providers.interactiveproviderbehavior) provides a quick and easy way to connect to the Microsoft Identity platform and Microsoft Graph.  It is built on top of the Graph SDK's authentication providers, but allows usage from XAML.
+The [InteractiveProviderBehavior](/dotnet/api/microsoft.toolkit.graph.providers.interactiveproviderbehavior) provides a quick and easy way to connect to the Microsoft Identity platform and Microsoft Graph.  It is built on top of the Graph SDK's authentication providers, but allows usage from XAML.
 
 Add this behavior to your application's main page. It only needs to be added to a single page to bootstrap all the other Graph enabled XAML controls.
 
@@ -30,7 +30,7 @@ Add this behavior to your application's main page. It only needs to be added to 
 ## WPF
 
 > [!IMPORTANT]
-> This provider must be initialized in your WPF app when using the XAML Graph controls from [XAML Islands](https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/xaml-islands). The same syntax above is used; however, you must include the [Microsoft.Toolkit.Wpf.Graph.Providers](https://www.nuget.org/packages/Microsoft.Toolkit.Wpf.Graph.Providers) NuGet package instead.
+> This provider must be initialized in your WPF app when using the XAML Graph controls from [XAML Islands](/windows/apps/desktop/modernize/xaml-islands). The same syntax above is used; however, you must include the [Microsoft.Toolkit.Wpf.Graph.Providers](https://www.nuget.org/packages/Microsoft.Toolkit.Wpf.Graph.Providers) NuGet package instead.
 
 ## Properties
 
@@ -55,4 +55,4 @@ Add this behavior to your application's main page. It only needs to be added to 
 ## Related Topics
 
 * [Graph SDK Authentication Providers](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth)
-* [App Registration Quick-Start for Client Id](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)
+* [App Registration Quick-Start for Client Id](/azure/active-directory/develop/quickstart-register-app)

--- a/docs/graph/providers/MockProviderBehavior.md
+++ b/docs/graph/providers/MockProviderBehavior.md
@@ -10,7 +10,7 @@ dev_langs:
 # MockProviderBehavior XAML Behavior
 
 <!-- Describe your control -->
-The [MockProviderBehavior](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.graph.providers.mockproviderbehavior) provides sample data from the Microsoft Graph for demonstration and learning purposes only.
+The [MockProviderBehavior](/dotnet/api/microsoft.toolkit.graph.providers.mockproviderbehavior) provides sample data from the Microsoft Graph for demonstration and learning purposes only.
 
 Add this behavior to your application's main page. It only needs to be added to a single page to bootstrap all the other Graph enabled XAML controls.
 

--- a/docs/helpers/AdvancedCollectionView.md
+++ b/docs/helpers/AdvancedCollectionView.md
@@ -10,17 +10,17 @@ dev_langs:
 
 # AdvancedCollectionView
 
-The [AdvancedCollectionView](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.advancedcollectionview) is a collection view implementation that support filtering, sorting and incremental loading. It's meant to be used in a viewmodel.
+The [AdvancedCollectionView](/dotnet/api/microsoft.toolkit.uwp.ui.advancedcollectionview) is a collection view implementation that support filtering, sorting and incremental loading. It's meant to be used in a viewmodel.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=AdvancedCollectionView)
 
 ## Usage
 
-In your viewmodel instead of having a public [IEnumerable](https://docs.microsoft.com/dotnet/core/api/system.collections.generic.ienumerable-1) of some sort to be bound to an eg. [Listview](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls.ListView), create a public AdvancedCollectionView and pass your list in the constructor to it. If you've done that you can use the many useful features it provides:
+In your viewmodel instead of having a public [IEnumerable](/dotnet/core/api/system.collections.generic.ienumerable-1) of some sort to be bound to an eg. [Listview](/uwp/api/Windows.UI.Xaml.Controls.ListView), create a public AdvancedCollectionView and pass your list in the constructor to it. If you've done that you can use the many useful features it provides:
 
 * sorting your list using the `SortDirection` helper: specify any number of property names to sort on with the direction desired
-* filtering your list using a [Predicate](https://docs.microsoft.com/dotnet/core/api/system.predicate-1): this will automatically filter your list only to the items that pass the check by the predicate provided
+* filtering your list using a [Predicate](/dotnet/core/api/system.predicate-1): this will automatically filter your list only to the items that pass the check by the predicate provided
 * deferring notifications using the `NotificationDeferrer` helper: with a convenient _using_ pattern you can increase performance while doing large-scale modifications in your list by waiting with updates until you've completed your work
 * incremental loading: if your source collection supports the feature then AdvancedCollectionView will do as well (it simply forwards the calls)
 * live shaping: when constructing the `AdvancedCollectionView` you may specify that the collection use live shaping. This means that the collection will re-filter or re-sort if there are changes to the sort properties or filter properties that are specified using `ObserveFilterProperty`
@@ -141,7 +141,7 @@ YourListView.ItemsSource = acv
 |  IsCurrentAfterLast  |                                                   bool                                                   |  Gets a value indicating whether the current item is after the last visible item  |
 | IsCurrentBeforeFirst |                                                   bool                                                   | Gets a value indicating whether the current item is before the first visible item |
 |      IsReadOnly      |                                                   bool                                                   |          Get a value indicating whether this CollectionView is read only          |
-|   SortDescriptions   | IList<[SortDescription](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.sortdescription)> |                  Gets SortDescriptions to sort the visible items                  |
+|   SortDescriptions   | IList<[SortDescription](/dotnet/api/microsoft.toolkit.uwp.ui.sortdescription)> |                  Gets SortDescriptions to sort the visible items                  |
 |        Source        |                                               IEnumerable                                                |                              Gets or sets the source                              |
 |   SourceCollection   |                                               IEnumerable                                                |                            Gets the source collection                             |
 |      this[int]       |                                                   int                                                    |                  Gets or sets the element at the specified index                  |
@@ -157,7 +157,7 @@ YourListView.ItemsSource = acv
 |        DeferRefresh()        |                                                     IDisposable                                                     |             Stops refreshing until it is disposed             |
 |       IndexOf(Object)        |                                                         int                                                         |                    Return index of an item                    |
 |    Insert(Int32, Object)     |                                                        void                                                         |             Insert an item in a particular place              |
-|  LoadMoreItemsAsync(UInt32)  | IAsyncOperation<[LoadMoreItemsResult](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Data.LoadMoreItemsResult)> |                Load more items from the source                |
+|  LoadMoreItemsAsync(UInt32)  | IAsyncOperation<[LoadMoreItemsResult](/uwp/api/Windows.UI.Xaml.Data.LoadMoreItemsResult)> |                Load more items from the source                |
 |    MoveCurrentTo(Object)     |                                                        bool                                                         |   Move current index to item. Returns success of operation    |
 |     MoveCurrentToFirst()     |                                                        bool                                                         | Move current item to first item. Returns success of operation |
 |     MoveCurrentToLast()      |                                                        bool                                                         | Move current item to last item. Returns success of operation  |
@@ -181,7 +181,7 @@ YourListView.ItemsSource = acv
 
 _What source can I use?_
 
-It's not necessary to use an eg. [ObservableCollection](https://docs.microsoft.com/dotnet/core/api/system.collections.objectmodel.observablecollection-1) to use the AdvancedCollectionView. It works as expected even when providing a simple [List](https://docs.microsoft.com/dotnet/core/api/system.collections.generic.list-1) in the constructor.
+It's not necessary to use an eg. [ObservableCollection](/dotnet/core/api/system.collections.objectmodel.observablecollection-1) to use the AdvancedCollectionView. It works as expected even when providing a simple [List](/dotnet/core/api/system.collections.generic.list-1) in the constructor.
 
 _Any performance guidelines?_
 

--- a/docs/helpers/BackgroundTaskHelper.md
+++ b/docs/helpers/BackgroundTaskHelper.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # Background Task Helper
 
-The [Background Task Helper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.backgroundtaskhelper) helps users interact with background tasks in an easier manner.
+The [Background Task Helper](/dotnet/api/microsoft.toolkit.uwp.helpers.backgroundtaskhelper) helps users interact with background tasks in an easier manner.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=BackgroundTaskHelper)
@@ -34,11 +34,11 @@ Dim registered As BackgroundTaskRegistration = BackgroundTaskHelper.Register("Ta
 
 | Methods | Return Type | Description |
 | -- | -- | -- |
-| GetBackgroundTask(String) | [IBackgroundTaskRegistration](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.Background.IBackgroundTaskRegistration) | Get the registered background task of the given type |
+| GetBackgroundTask(String) | [IBackgroundTaskRegistration](/uwp/api/Windows.ApplicationModel.Background.IBackgroundTaskRegistration) | Get the registered background task of the given type |
 | GetBackgroundTask(Type) | IBackgroundTaskRegistration | Get the registered background task of the given type |
 | IsBackgroundTaskRegistered(String) | bool | Check if a background task is registered |
 | IsBackgroundTaskRegistered(Type) | bool | Check if a background task is registered |
-| Register(String, IBackgroundTrigger, Boolean, Boolean, IBackgroundCondition[]) | [BackgroundTaskRegistration](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.Background.BackgroundTaskRegistration) | Registers under the Single Process Model |
+| Register(String, IBackgroundTrigger, Boolean, Boolean, IBackgroundCondition[]) | [BackgroundTaskRegistration](/uwp/api/Windows.ApplicationModel.Background.BackgroundTaskRegistration) | Registers under the Single Process Model |
 | Register(Type, IBackgroundTrigger, Boolean, Boolean, IBackgroundCondition[]) | BackgroundTaskRegistration | Register a background task with conditions |
 | Register(String, String, IBackgroundTrigger, Boolean, Boolean, IBackgroundCondition[]) | BackgroundTaskRegistration | Register a background task with conditions |
 | Unregister(String, Boolean) | void | Unregister a background task |

--- a/docs/helpers/BindableValueHolder.md
+++ b/docs/helpers/BindableValueHolder.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # BindableValueHolder
 
-The [BindableValueHolder](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.helpers.bindablevalueholder) lets users change several objects' states at a time.
+The [BindableValueHolder](/dotnet/api/microsoft.toolkit.uwp.ui.helpers.bindablevalueholder) lets users change several objects' states at a time.
 
 ## Syntax
 

--- a/docs/helpers/BluetoothLEHelper.md
+++ b/docs/helpers/BluetoothLEHelper.md
@@ -48,7 +48,7 @@ The BluetoothLEHelper class provides functionality to easily enumerate, connect 
 | BluetoothAddressAsString |                                                string                                                 |    Gets the bluetooth address of this device as a string    |
 | BluetoothAddressAsUlong  |                                                 ulong                                                 |          Gets the bluetooth address of this device          |
 |    BluetoothLEDevice     |                                           BluetoothLEDevice                                           |       Gets the base bluetooth device this class wraps       |
-|        DeviceInfo        | [DeviceInformation](https://docs.microsoft.com/uwp/api/Windows.Devices.Enumeration.DeviceInformation) | Gets the device information for the device this class wraps |
+|        DeviceInfo        | [DeviceInformation](/uwp/api/Windows.Devices.Enumeration.DeviceInformation) | Gets the device information for the device this class wraps |
 |        ErrorText         |                                                string                                                 |  Gets the error text when connecting to this device fails   |
 |          Glyph           |                                              BitmapImage                                              |       Gets or sets the glyph of this bluetooth device       |
 |       IsConnected        |                                                 bool                                                  |  Gets a value indicating whether this device is connected   |

--- a/docs/helpers/CameraHelper.md
+++ b/docs/helpers/CameraHelper.md
@@ -13,7 +13,7 @@ dev_langs:
 The **CameraHelper** provides helper methods to easily use the available camera frame sources to preview video, capture video frames and software bitmaps. The helper currently shows camera frame sources that support color video preview or video record streams. 
 
 > [!IMPORTANT]
-> Make sure you have the [webcam capability](https://docs.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations#device-capabilities) enabled for your app to access the device's camera.
+> Make sure you have the [webcam capability](/windows/uwp/packaging/app-capability-declarations#device-capabilities) enabled for your app to access the device's camera.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=CameraHelper)
@@ -78,7 +78,7 @@ End Sub
 
 As a developer, you will need to make sure the CameraHelper resources are cleaned up when appropriate. For example, if the CameraHelper is only used on one page, make sure to clean up the CameraHelper when navigating away from the page.
 
-Likewise, make sure to handle app [suspending](https://docs.microsoft.com/windows/uwp/launch-resume/suspend-an-app) and [resuming](https://docs.microsoft.com/en-us/windows/uwp/launch-resume/resume-an-app) - CameraHelper should be cleaned up when suspending and re-initialized when resuming.
+Likewise, make sure to handle app [suspending](/windows/uwp/launch-resume/suspend-an-app) and [resuming](/windows/uwp/launch-resume/resume-an-app) - CameraHelper should be cleaned up when suspending and re-initialized when resuming.
 
 Call `CameraHelper.CleanupAsync()` to clean up all internal resources. See the [CameraHelper sample page in the sample app](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/CameraHelper) for full example.
 

--- a/docs/helpers/Colors.md
+++ b/docs/helpers/Colors.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # Colors Helper
 
-The [Colors Helper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.colorhelper) lets users convert colors from text names, HTML hex, HSV, or HSL to Windows UI Colors (and back again of course).
+The [Colors Helper](/dotnet/api/microsoft.toolkit.uwp.helpers.colorhelper) lets users convert colors from text names, HTML hex, HSV, or HSL to Windows UI Colors (and back again of course).
 
 ## Syntax
 
@@ -49,8 +49,8 @@ Dim redColor As Windows.UI.Color = "Red".ToColor()
 | FromHsv(Double, Double, Double, Double) | int | Returns a Color struct based on HSV model. Hue: 0-360, Saturation:  0-1, Lightness:  0-1, Alpha:  0-1 |
 | ToColor(String) | Color | Returns a color based on XAML color string |
 | ToHex(Color) | string | Converts a Color value to a string representation of the value in hexadecimal |
-| ToHsl(Color) | [HslColor](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.hslcolor) | Converts an RGBA Color the HSL representation |
-| ToHsv(Color) | [HsvColor](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.hsvcolor) | Converts an RGBA Color the HSV representation |
+| ToHsl(Color) | [HslColor](/dotnet/api/microsoft.toolkit.uwp.hslcolor) | Converts an RGBA Color the HSL representation |
+| ToHsv(Color) | [HsvColor](/dotnet/api/microsoft.toolkit.uwp.hsvcolor) | Converts an RGBA Color the HSV representation |
 | ToInt(Color) | int | Returns the color value as a premultiplied Int32 - 4 byte ARGB structure |
 
 ## Sample Code

--- a/docs/helpers/Converters.md
+++ b/docs/helpers/Converters.md
@@ -11,21 +11,21 @@ Commonly used **converters** that allow the data to be modified as it passes thr
 
 | Converter | Purpose |
 | --- | --- |
-| [BoolNegationConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.boolnegationconverter?view=uwp-toolkit-dotnet) | Converts a boolean to the inverse value (True to False and vice versa) |
-| [BoolToObjectConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.booltoobjectconverter?view=uwp-toolkit-dotnet) | Converts a boolean value into an object. The converted value is selected between the values of TrueValue and FalseValue properties |
-| [BoolToVisibilityConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.booltovisibilityconverter?view=uwp-toolkit-dotnet) | Converts a boolean value into a Visibility enumeration |
-| [CollectionVisibilityConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.collectionvisibilityconverter?view=uwp-toolkit-dotnet) | Converts a collection into a Visibility enumeration (Collapsed if the given collection is empty or null) |
-| [DoubleToObjectConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.doubletoobjectconverter?view=uwp-toolkit-dotnet) | Converts a double value into an object based on a value to be greater than, less than, or in-between. |
-| [DoubleToVisibilityConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.doubletovisibilityconverter?view=uwp-toolkit-dotnet) | Converts a double value into a Visibility enumeration based on a value to be greater than, less than, or in-between. |
-| [EmptyCollectionToObjectConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.emptycollectiontoobjectconverter?view=uwp-toolkit-dotnet) | Converts a collection into an object. The converted value is selected between the values of EmptyValue and NotEmptyValue properties |
-| [EmptyObjectToObjectConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.emptyobjecttoobjectconverter?view=uwp-toolkit-dotnet) | Converts a check on a null value into an object. The converted value is selected between the values of EmptyValue and NonEmptyValue properties | 
-| [EmptyStringToObjectConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.emptystringtoobjectconverter?view=uwp-toolkit-dotnet) | Converts a string into an object. The converted value is selected between the values of EmptyValue and NotEmptyValue properties |
-| [FormatStringConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.formatstringconverter?view=uwp-toolkit-dotnet) | Converts an [IFormattable](https://docs.microsoft.com/dotnet/api/system.string.format?view=netframework-4.7) value into a string. The ConverterParameter provides the string format |
-| [ResourceNameToResourceStringConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.resourcenametoresourcestringconverter?view=uwp-toolkit-dotnet) | Converter to look up the source string in the App Resources strings and returns its value, if found |
-| [StringFormatConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.stringformatconverter?view=uwp-toolkit-dotnet) | Converts a source object to the formatted string version using [string.Format](https://docs.microsoft.com/dotnet/api/system.string.format?view=netframework-4.7). The ConverterParameter provides the string format |
-| [StringVisibilityConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.stringvisibilityconverter?view=uwp-toolkit-dotnet) | Converts a string value into a Visibility enumeration (if the value is null or empty returns a collapsed value) |
-| [ToolbarFormatActiveConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.toolbarformatactiveconverter?view=uwp-toolkit-dotnet) | Compares if Formats are equal and returns bool |
-| [VisibilityToBoolConverter](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.converters.visibilitytoboolconverter?view=uwp-toolkit-dotnet) | This class converts a Visibility enumeration to a boolean value |
+| [BoolNegationConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.boolnegationconverter?view=uwp-toolkit-dotnet) | Converts a boolean to the inverse value (True to False and vice versa) |
+| [BoolToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.booltoobjectconverter?view=uwp-toolkit-dotnet) | Converts a boolean value into an object. The converted value is selected between the values of TrueValue and FalseValue properties |
+| [BoolToVisibilityConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.booltovisibilityconverter?view=uwp-toolkit-dotnet) | Converts a boolean value into a Visibility enumeration |
+| [CollectionVisibilityConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.collectionvisibilityconverter?view=uwp-toolkit-dotnet) | Converts a collection into a Visibility enumeration (Collapsed if the given collection is empty or null) |
+| [DoubleToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.doubletoobjectconverter?view=uwp-toolkit-dotnet) | Converts a double value into an object based on a value to be greater than, less than, or in-between. |
+| [DoubleToVisibilityConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.doubletovisibilityconverter?view=uwp-toolkit-dotnet) | Converts a double value into a Visibility enumeration based on a value to be greater than, less than, or in-between. |
+| [EmptyCollectionToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.emptycollectiontoobjectconverter?view=uwp-toolkit-dotnet) | Converts a collection into an object. The converted value is selected between the values of EmptyValue and NotEmptyValue properties |
+| [EmptyObjectToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.emptyobjecttoobjectconverter?view=uwp-toolkit-dotnet) | Converts a check on a null value into an object. The converted value is selected between the values of EmptyValue and NonEmptyValue properties | 
+| [EmptyStringToObjectConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.emptystringtoobjectconverter?view=uwp-toolkit-dotnet) | Converts a string into an object. The converted value is selected between the values of EmptyValue and NotEmptyValue properties |
+| [FormatStringConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.formatstringconverter?view=uwp-toolkit-dotnet) | Converts an [IFormattable](/dotnet/api/system.string.format?view=netframework-4.7) value into a string. The ConverterParameter provides the string format |
+| [ResourceNameToResourceStringConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.resourcenametoresourcestringconverter?view=uwp-toolkit-dotnet) | Converter to look up the source string in the App Resources strings and returns its value, if found |
+| [StringFormatConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.stringformatconverter?view=uwp-toolkit-dotnet) | Converts a source object to the formatted string version using [string.Format](/dotnet/api/system.string.format?view=netframework-4.7). The ConverterParameter provides the string format |
+| [StringVisibilityConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.stringvisibilityconverter?view=uwp-toolkit-dotnet) | Converts a string value into a Visibility enumeration (if the value is null or empty returns a collapsed value) |
+| [ToolbarFormatActiveConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.toolbarformatactiveconverter?view=uwp-toolkit-dotnet) | Compares if Formats are equal and returns bool |
+| [VisibilityToBoolConverter](/dotnet/api/microsoft.toolkit.uwp.ui.converters.visibilitytoboolconverter?view=uwp-toolkit-dotnet) | This class converts a Visibility enumeration to a boolean value |
 
 ## BoolToObjectConverter Examples
 
@@ -81,7 +81,7 @@ and using it like that :
 ## BoolToVisibilityConverter Examples
 
 `BoolToVisibilityConverter` can be used to easily change a boolean value to a Visibility based one. 
-If targeting 14393 or later, this is done automatically through [x:Bind](https://docs.microsoft.com/windows/uwp/xaml-platform/x-bind-markup-extension).  First, declare the converter in your resources:
+If targeting 14393 or later, this is done automatically through [x:Bind](/windows/uwp/xaml-platform/x-bind-markup-extension).  First, declare the converter in your resources:
 
 ```xaml
 <Page.Resources>
@@ -156,7 +156,7 @@ this can be used as follows to hide a list with no items and instead show text t
 
 ## StringFormatConverter Examples
 
-`StringFormatConverter` allows you to format a string property upon binding wrapping [string.Format](https://docs.microsoft.com/dotnet/api/system.string.format?view=netframework-4.7).  
+`StringFormatConverter` allows you to format a string property upon binding wrapping [string.Format](/dotnet/api/system.string.format?view=netframework-4.7).  
 It only allows for a single input value (the binding string), but can be formatted with the regular string.Format
 methods.  First, add it to your page resources:
 

--- a/docs/helpers/DeepLinkParsers.md
+++ b/docs/helpers/DeepLinkParsers.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # DeepLinkParser
 
-The [DeepLinkParser Class](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.deeplinkparser) provides a way to create, from `IActivatedEventArgs` a `Dictionary<string,string>`-inheriting object that provides an additional `.Root` property to pull the base path of the URI (eg: in `MainPage/Options?option1=value1`, `.Root` would be `MainPage/Options`.
+The [DeepLinkParser Class](/dotnet/api/microsoft.toolkit.uwp.helpers.deeplinkparser) provides a way to create, from `IActivatedEventArgs` a `Dictionary<string,string>`-inheriting object that provides an additional `.Root` property to pull the base path of the URI (eg: in `MainPage/Options?option1=value1`, `.Root` would be `MainPage/Options`.
 Once you have an instance, simply saying `instance["optionName"]` will pull the value from the querystring for that option.
 
 ### Properties
@@ -25,7 +25,7 @@ Once you have an instance, simply saying `instance["optionName"]` will pull the 
 | -- | -- | -- |
 | Create(String) | DeepLinkParser | Creates an instance of `DeepLinkParser` for the given `string` |
 | Create(Uri) | DeepLinkParser | Creates an instance of DeepLinkParser for the given Uri |
-| Create(IActivatedEventArgs) | DeepLinkParser | Creates an instance of DeepLinkParser for the given [IActivatedEventArgs](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.Activation.IActivatedEventArgs) |
+| Create(IActivatedEventArgs) | DeepLinkParser | Creates an instance of DeepLinkParser for the given [IActivatedEventArgs](/uwp/api/Windows.ApplicationModel.Activation.IActivatedEventArgs) |
 | ValidateSourceUri(String) | Uri | Validates the source URI |
 
 ### Example
@@ -64,7 +64,7 @@ If e.PrelaunchActivated = False Then
 
 ## CollectionFormingDeepLinkParser
 
-The [CollectionFormingDeepLinkParser Class](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.collectionformingdeeplinkparser) will to be able to do something like `?pref=this&pref=that&pref=theOther` and have a pull of `pref` come back with `this,that,theOther` as its value. This derivative of `DeepLinkParser` provides this functionality.
+The [CollectionFormingDeepLinkParser Class](/dotnet/api/microsoft.toolkit.uwp.helpers.collectionformingdeeplinkparser) will to be able to do something like `?pref=this&pref=that&pref=theOther` and have a pull of `pref` come back with `this,that,theOther` as its value. This derivative of `DeepLinkParser` provides this functionality.
 
 ### Example
 
@@ -107,7 +107,7 @@ The method that does the heavy lifting of parsing in to the `Dictionary<string,s
 
 ## QueryParameterCollection
 
-The [QueryParameterCollection](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.queryparametercollection) helper class aids in the creation of a `Collection<KeyValuePair<string,string>>` populated with they key-value pairs of all parameters in a query string.
+The [QueryParameterCollection](/dotnet/api/microsoft.toolkit.uwp.helpers.queryparametercollection) helper class aids in the creation of a `Collection<KeyValuePair<string,string>>` populated with they key-value pairs of all parameters in a query string.
 
 ### Example
 

--- a/docs/helpers/DispatcherHelper.md
+++ b/docs/helpers/DispatcherHelper.md
@@ -10,13 +10,13 @@ dev_langs:
 
 # DispatcherHelper
 
-The DispatcherHelper class enables easy interaction with [CoreDispatcher](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.core.coredispatcher.aspx), mainly in the case of executing a block of code on the UI thread from a non-UI thread.
+The DispatcherHelper class enables easy interaction with [CoreDispatcher](/uwp/api/Windows.UI.Core.CoreDispatcher), mainly in the case of executing a block of code on the UI thread from a non-UI thread.
 
 _What is included in the helper?_
 
-- Extension method with overloads for [CoreDispatcher](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.core.coredispatcher.aspx) class.
+- Extension method with overloads for [CoreDispatcher](/uwp/api/Windows.UI.Core.CoreDispatcher) class.
 
-- Extension method with overloads for [CoreApplicationView](https://msdn.microsoft.com/en-us/library/windows/apps/windows.applicationmodel.core.coreapplicationview.aspx) (for multi window applications).
+- Extension method with overloads for [CoreApplicationView](/uwp/api/Windows.ApplicationModel.Core.CoreApplicationView) (for multi window applications).
 
 - Static helper methods for executing a specific function on the UI thread of the current application's main window.
 

--- a/docs/helpers/HttpHelper.md
+++ b/docs/helpers/HttpHelper.md
@@ -11,9 +11,9 @@ dev_langs:
 # HttpHelper
 
 > [!WARNING]
-> (This API is obsolete and will be removed in the future. Please use [System.Net.Http.HttpClient](https://msdn.microsoft.com/library/system.net.http.httpclient(v=vs.110).aspx) or [Windows.Web.Http.HttpClient](https://docs.microsoft.com/uwp/api/Windows.Web.Http.HttpClient) directly)
+> (This API is obsolete and will be removed in the future. Please use [System.Net.Http.HttpClient](/dotnet/api/system.net.http.httpclient) or [Windows.Web.Http.HttpClient](/uwp/api/Windows.Web.Http.HttpClient) directly)
 
-The [HttpHelper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.httphelper) represents an HTTP request message including headers.
+The [HttpHelper](/dotnet/api/microsoft.toolkit.uwp.httphelper) represents an HTTP request message including headers.
 
 ## Syntax
 

--- a/docs/helpers/HttpHelperRequest.md
+++ b/docs/helpers/HttpHelperRequest.md
@@ -11,10 +11,10 @@ dev_langs:
 # HttpHelperRequest
 
 > [!WARNING]
-> (This API is obsolete and will be removed in the future. Please use [System.Net.Http.HttpRequestMessage](https://msdn.microsoft.com/library/system.net.http.httprequestmessage(v=vs.110).aspx) 
-> or [Windows.Web.Http.HttpRequestMessage](https://docs.microsoft.com/uwp/api/windows.web.http.httprequestmessage) directly)
+> (This API is obsolete and will be removed in the future. Please use [System.Net.Http.HttpRequestMessage](/dotnet/api/system.net.http.httprequestmessage) 
+> or [Windows.Web.Http.HttpRequestMessage](/uwp/api/windows.web.http.httprequestmessage) directly)
 
-The [HttpHelperRequest](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.httphelperrequest) represents an HTTP request message including headers. 
+The [HttpHelperRequest](/dotnet/api/microsoft.toolkit.uwp.httphelperrequest) represents an HTTP request message including headers. 
 
 ```csharp
 var request = new HttpHelperRequest(uri, HttpMethod.Get);
@@ -29,8 +29,8 @@ The **HttpHelperRequest** class has these constructors.
 
 | Constructor | Description |
 | ----------  | ----------- |
-| HttpHelperRequest([Uri](https://msdn.microsoft.com/library/system.uri.aspx))  | Initializes a new instance of the HttpHelperRequest class with an HTTP Get method and a request Uri.|
-| HttpHelperRequest([HttpMethod](https://msdn.microsoft.com/en-us/library/windows/apps/windows.web.http.httpmethod.aspx), [Uri](https://msdn.microsoft.com/library/system.uri.aspx))  | Initializes a new instance of the HttpRequestMessage class with an HTTP method and a request Uri.|
+| HttpHelperRequest([Uri](/dotnet/api/system.uri))  | Initializes a new instance of the HttpHelperRequest class with an HTTP Get method and a request Uri.|
+| HttpHelperRequest([HttpMethod](/uwp/api/Windows.Web.Http.HttpMethod), [Uri](/dotnet/api/system.uri))  | Initializes a new instance of the HttpRequestMessage class with an HTTP method and a request Uri.|
 
 ## Methods
 
@@ -38,7 +38,7 @@ The **HttpHelperRequest** class has these methods. It also inherits from **Objec
 
 | Method | Description |
 | ------ | ----------- |
-| ToHttpRequestMessage() | Returns an instance of [**HttpRequestMessage**](https://msdn.microsoft.com/en-us/library/windows/apps/windows.web.http.httprequestmessage.aspx) representing current HttpHelperRequest object. |
+| ToHttpRequestMessage() | Returns an instance of [**HttpRequestMessage**](/uwp/api/Windows.Web.Http.HttpRequestMessage) representing current HttpHelperRequest object. |
 | Dispose() | Performs tasks associated with freeing, releasing, or resetting unmanaged resources. |
 | ToString() | Returns a string that represents the current HttpHelperRequest object. |
 

--- a/docs/helpers/HttpHelperResponse.md
+++ b/docs/helpers/HttpHelperResponse.md
@@ -11,10 +11,10 @@ dev_langs:
 # HttpHelperResponse
 
 > [!WARNING]
-> (This API is obsolete and will be removed in the future. Please use [System.Net.Http.HttpResponseMessage](https://msdn.microsoft.com/library/system.net.http.httpresponsemessage(v=vs.110).aspx) 
-> or [Windows.Web.Http.HttpResponseMessage](https://docs.microsoft.com/uwp/api/Windows.Web.Http.HttpResponseMessage) directly)
+> (This API is obsolete and will be removed in the future. Please use [System.Net.Http.HttpResponseMessage](/dotnet/api/system.net.http.httpresponsemessage) 
+> or [Windows.Web.Http.HttpResponseMessage](/uwp/api/Windows.Web.Http.HttpResponseMessage) directly)
 
-[HttpHelperResponse](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.httphelperresponse) represents an HTTP response message including headers. 
+[HttpHelperResponse](/dotnet/api/microsoft.toolkit.uwp.httphelperresponse) represents an HTTP response message including headers. 
 
 ## Example
 
@@ -36,7 +36,7 @@ The **HttpHelperResponse** class has these constructors.
 
 | Constructor | Description |
 | ----------  | ----------- |
-| HttpHelperResponse([HttpResponseMessage](https://msdn.microsoft.com/en-us/library/windows/apps/windows.web.http.httpresponsemessage.aspx))  | Initializes an instance of the HttpHelperRequest class with supplied HttpHelperResponse. |
+| HttpHelperResponse([HttpResponseMessage](/uwp/api/Windows.Web.Http.HttpResponseMessage))  | Initializes an instance of the HttpHelperRequest class with supplied HttpHelperResponse. |
 
 ## Properties
 

--- a/docs/helpers/ImageCache.md
+++ b/docs/helpers/ImageCache.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # ImageCache
 
-The [ImageCache](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.imagecache) provides methods and tools to cache images in a temporary local folder. ImageCache also supports optional in-memory layer of caching, that provides better performance when same images are requested multiple times (like in long virtualized lists of images). This type of caching is disabled by default, but can be enabled by setting MaxMemoryCacheSize to desired size. For example: setting MaxMemoryCacheSize to 100 means that 100 last requested images will be held in memory to be instantly available, without disk reads.
+The [ImageCache](/dotnet/api/microsoft.toolkit.uwp.ui.imagecache) provides methods and tools to cache images in a temporary local folder. ImageCache also supports optional in-memory layer of caching, that provides better performance when same images are requested multiple times (like in long virtualized lists of images). This type of caching is disabled by default, but can be enabled by setting MaxMemoryCacheSize to desired size. For example: setting MaxMemoryCacheSize to 100 means that 100 last requested images will be held in memory to be instantly available, without disk reads.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=ImageCache)

--- a/docs/helpers/IncrementalLoadingCollection.md
+++ b/docs/helpers/IncrementalLoadingCollection.md
@@ -10,12 +10,12 @@ dev_langs:
 
 # Incremental Loading Collection Helpers
 
-The **IncrementalLoadingCollection** helpers greatly simplify the definition and usage of collections whose items can be loaded incrementally only when needed by the view, i.e., when user scrolls a [ListView](https://msdn.microsoft.com/library/windows/apps/windows.ui.xaml.controls.listview.aspx) or a [GridView](https://msdn.microsoft.com/library/windows/apps/windows.ui.xaml.controls.gridview.aspx).
+The **IncrementalLoadingCollection** helpers greatly simplify the definition and usage of collections whose items can be loaded incrementally only when needed by the view, i.e., when user scrolls a [ListView](/uwp/api/Windows.UI.Xaml.Controls.ListView) or a [GridView](/uwp/api/Windows.UI.Xaml.Controls.GridView).
 
 | Helper | Purpose |
 | --- | --- |
-|[IIncrementalSource](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.collections.iincrementalsource-1) | An interface that represents a data source whose items can be loaded incrementally. |
-|[IncrementalLoadingCollection](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.incrementalloadingcollection-2) | An extension of [ObservableCollection](https://msdn.microsoft.com/library/ms668604.aspx) such that its items are loaded only when needed. |
+|[IIncrementalSource](/dotnet/api/microsoft.toolkit.collections.iincrementalsource-1) | An interface that represents a data source whose items can be loaded incrementally. |
+|[IncrementalLoadingCollection](/dotnet/api/microsoft.toolkit.uwp.incrementalloadingcollection-2) | An extension of [ObservableCollection](/dotnet/api/system.collections.objectmodel.observablecollection-1) such that its items are loaded only when needed. |
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=Incremental%20Loading%20Collection)
@@ -28,7 +28,7 @@ The **IncrementalLoadingCollection** helpers greatly simplify the definition and
 |   HasMoreItems   |                                   bool                                    |                         Gets a value indicating whether the collection contains more items to retrieve                         |
 |    IsLoading     |                                   bool                                    |                                   Gets a value indicating whether new items are being loaded                                   |
 |   ItemsPerPage   |                                    int                                    |                    Gets a value indicating how many items that must be retrieved for each incremental call                     |
-|   OnEndLoading   | [Action](https://msdn.microsoft.com/library/system.action(v=vs.110).aspx) |                             Gets or sets an Action that is called when a retrieval operation ends                              |
+|   OnEndLoading   | [Action](/dotnet/api/system.action) |                             Gets or sets an Action that is called when a retrieval operation ends                              |
 |     OnError      |                             Action<Exception>                             | Gets or sets an Action that is called if an error occours during data retrieval. The actual Exception is passed as an argument |
 |  OnStartLoading  |                                  Action                                   |                            Gets or sets an Action that is called when a retrieval operation begins                             |
 
@@ -119,7 +119,7 @@ End Class
 
 The *GetPagedItemsAsync* method is invoked everytime the view need to show more items.
 
-`IncrementalLoadingCollection` can then be bound to a [ListView](https://msdn.microsoft.com/library/windows/apps/windows.ui.xaml.controls.listview.aspx) or a [GridView-like](https://msdn.microsoft.com/library/windows/apps/windows.ui.xaml.controls.gridview.aspx) control:
+`IncrementalLoadingCollection` can then be bound to a [ListView](/uwp/api/Windows.UI.Xaml.Controls.ListView) or a [GridView-like](/uwp/api/Windows.UI.Xaml.Controls.GridView) control:
 
 ```csharp
 var collection = new IncrementalLoadingCollection<PeopleSource, Person>();

--- a/docs/helpers/NetworkHelper.md
+++ b/docs/helpers/NetworkHelper.md
@@ -10,9 +10,9 @@ dev_langs:
 
 # NetworkHelper
 
-The [NetworkHelper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.connectivity.networkhelper) class provides functionality to monitor changes in network connection and allows users to query for network information without additional lookups.
+The [NetworkHelper](/dotnet/api/microsoft.toolkit.uwp.connectivity.networkhelper) class provides functionality to monitor changes in network connection and allows users to query for network information without additional lookups.
 
-It exposes network information though a property called ConnectionInformation. The [ConnectionInformation](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.connectivity.connectioninformation) holds information about ConnectionType, ConnectivityLevel, ConnectionCost, SignalStrength, Internet Connectivity and more.
+It exposes network information though a property called ConnectionInformation. The [ConnectionInformation](/dotnet/api/microsoft.toolkit.uwp.connectivity.connectioninformation) holds information about ConnectionType, ConnectivityLevel, ConnectionCost, SignalStrength, Internet Connectivity and more.
 
 **_What is a metered connection?_**
 A metered connection is an Internet connection that has a data limit or cost associated with it. Cellular data connections are set as metered by default. Wi-Fi network connections can be set to metered, but aren't by default. Application developers should take metered nature of connection into account and reduce data usage.
@@ -24,16 +24,16 @@ A metered connection is an Internet connection that has a data limit or cost ass
 
 | Property | Type | Description |
 | -- | -- | -- |
-| ConnectionInformation | [ConnectionInformation](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.connectivity.connectioninformation) | Gets instance of ConnectionInformation |
+| ConnectionInformation | [ConnectionInformation](/dotnet/api/microsoft.toolkit.uwp.connectivity.connectioninformation) | Gets instance of ConnectionInformation |
 | Instance | NetworkHelper | Gets public singleton property |
 
 ## ConnectionInformation Properties
 
 |           Property            |                                                          Type                                                           |                                  Description                                  |
 |-------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-|        ConnectionCost         |           [ConnectionCost](https://docs.microsoft.com/uwp/api/Windows.Networking.Connectivity.ConnectionCost)           |       Gets connection cost for the current Internet Connection Profile        |
-|        ConnectionType         |       [ConnectionType](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.connectivity.connectiontype)        |       Gets connection type for the current Internet Connection Profile        |
-|       ConnectivityLevel       | [NetworkConnectivityLevel](https://docs.microsoft.com/uwp/api/Windows.Networking.Connectivity.NetworkConnectivityLevel) |      Gets connectivity level for the current Internet Connection Profile      |
+|        ConnectionCost         |           [ConnectionCost](/uwp/api/Windows.Networking.Connectivity.ConnectionCost)           |       Gets connection cost for the current Internet Connection Profile        |
+|        ConnectionType         |       [ConnectionType](/dotnet/api/microsoft.toolkit.uwp.connectivity.connectiontype)        |       Gets connection type for the current Internet Connection Profile        |
+|       ConnectivityLevel       | [NetworkConnectivityLevel](/uwp/api/Windows.Networking.Connectivity.NetworkConnectivityLevel) |      Gets connectivity level for the current Internet Connection Profile      |
 |      IsInternetAvailable      |                                                          bool                                                           | Gets a value indicating whether internet is available across all connections  |
 | IsInternetOnMeteredConnection |                                                          bool                                                           | Gets a value indicating whether if the current internet connection is metered |
 |         NetworkNames          |                                                  IReadOnlyList<string>                                                  |       Gets signal strength for the current Internet Connection Profile        |

--- a/docs/helpers/ObjectSerializer.md
+++ b/docs/helpers/ObjectSerializer.md
@@ -94,4 +94,4 @@ namespace Contoso.Helpers
 
 ## Related topics
 
-* [ObjectStorage](https://docs.microsoft.com/en-us/windows/communitytoolkit/helpers/objectstorage)
+* [ObjectStorage](./objectstorage.md)

--- a/docs/helpers/ObjectStorage.md
+++ b/docs/helpers/ObjectStorage.md
@@ -12,8 +12,8 @@ dev_langs:
 
 The Object Storage Helper will help you handle storage of generic objects within UWP applications, both locally and across all devices (roaming).
 
-- [LocalObjectStorageHelper Class](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.localobjectstoragehelper) store data in the Local environment (only on the current device)
-- [RoamingObjectStorageHelper Class](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.roamingobjectstoragehelper)
+- [LocalObjectStorageHelper Class](/dotnet/api/microsoft.toolkit.uwp.helpers.localobjectstoragehelper) store data in the Local environment (only on the current device)
+- [RoamingObjectStorageHelper Class](/dotnet/api/microsoft.toolkit.uwp.helpers.roamingobjectstoragehelper)
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=Object%20Storage)
@@ -51,7 +51,7 @@ LocalObjectStorageHelper and RoamingObjectStorageHelper have the same constructo
 
 ### Local Storage
 
-If you need to handle local saves of any object (generic), you can use [LocalObjectStorageHelper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.localobjectstoragehelper).
+If you need to handle local saves of any object (generic), you can use [LocalObjectStorageHelper](/dotnet/api/microsoft.toolkit.uwp.helpers.localobjectstoragehelper).
 
 ```csharp
 var helper = new LocalObjectStorageHelper();

--- a/docs/helpers/RemoteDeviceHelper.md
+++ b/docs/helpers/RemoteDeviceHelper.md
@@ -9,10 +9,10 @@ dev_langs:
 
 # RemoteDeviceHelper
 
-The [RemoteDeviceHelper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.remotedevicehelper) gives you a list of Remote Systems. All the systems must be signed in with the same Microsoft Account (MSA)
+The [RemoteDeviceHelper](/dotnet/api/microsoft.toolkit.uwp.helpers.remotedevicehelper) gives you a list of Remote Systems. All the systems must be signed in with the same Microsoft Account (MSA)
 
 > [!IMPORTANT]
-> Make sure you enable the [RemoteSystem capability](https://docs.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations#general-use-capabilities) in your app's `package.appxmanifest` to access remote system information.
+> Make sure you enable the [RemoteSystem capability](/windows/uwp/packaging/app-capability-declarations#general-use-capabilities) in your app's `package.appxmanifest` to access remote system information.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=RemoteDeviceHelper)
@@ -100,6 +100,6 @@ DevicesList.DataContext = _remoteDeviceHelper;
 
 * [Project Rome](https://developer.microsoft.com/en-us/windows/project-rome)
 * [Remote Systems Sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/RemoteSystems)
-* [Connected apps and devices (Project Rome)](https://docs.microsoft.com/en-us/windows/uwp/launch-resume/connected-apps-and-devices)
-* [Communicate with a remote app service](https://docs.microsoft.com/en-us/windows/uwp/launch-resume/communicate-with-a-remote-app-service)
+* [Connected apps and devices (Project Rome)](/windows/uwp/launch-resume/connected-apps-and-devices)
+* [Communicate with a remote app service](/windows/uwp/launch-resume/communicate-with-a-remote-app-service)
 * [AppServices Sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/AppServices)

--- a/docs/helpers/StorageFiles.md
+++ b/docs/helpers/StorageFiles.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # StorageFileHelper
 
-The [StorageFileHelper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.storagefilehelper) is a static utility class that provides functions to help with reading and writing of text and bytes to the disk.  These functions are all wrapped into Async tasks.
+The [StorageFileHelper](/dotnet/api/microsoft.toolkit.uwp.helpers.storagefilehelper) is a static utility class that provides functions to help with reading and writing of text and bytes to the disk.  These functions are all wrapped into Async tasks.
 
 ## Syntax
 

--- a/docs/helpers/Streams.md
+++ b/docs/helpers/Streams.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # Streams Helper
 
-There are several operations that apps need commonly to do against their APPX, or from the Internet that are not easy.  [Streams helper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.streamhelper) class wraps up some of the most common operations we need in multiple apps.
+There are several operations that apps need commonly to do against their APPX, or from the Internet that are not easy.  [Streams helper](/dotnet/api/microsoft.toolkit.uwp.helpers.streamhelper) class wraps up some of the most common operations we need in multiple apps.
 
 ## Some common scenarios
 

--- a/docs/helpers/SystemInformation.md
+++ b/docs/helpers/SystemInformation.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # SystemInformation
 
-The [SystemInformation](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.systeminformation?view=uwp-toolkit-dotnet) class is a static utility class that provides properties with some system, application and device information.
+The [SystemInformation](/dotnet/api/microsoft.toolkit.uwp.helpers.systeminformation?view=uwp-toolkit-dotnet) class is a static utility class that provides properties with some system, application and device information.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=SystemInformation)
@@ -17,15 +17,15 @@ The [SystemInformation](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.
 | Property | Type | Description |
 | -- | -- | -- |
 | ApplicationName | string | Gets the application's name as a `string` |
-| ApplicationVersion | [PackageVersion](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.PackageVersion) | Gets the application's version as a [PackageVersion](https://msdn.microsoft.com/library/windows/apps/xaml/windows.applicationmodel.packageversion.aspx) |
+| ApplicationVersion | [PackageVersion](/uwp/api/Windows.ApplicationModel.PackageVersion) | Gets the application's version as a [PackageVersion](/uwp/api/Windows.ApplicationModel.PackageVersion) |
 | AppUptime | TimeSpan | Gets the length of time this instance of the app has been running. |
 | AvailableMemory | float | Gets the available memory in _MB_ as a `float` |
-| Culture | CultureInfo | Gets the most preferred language by the user as a [CultureInfo](https://msdn.microsoft.com/library/windows/apps/xaml/system.globalization.cultureinfo(v=vs.105).aspx) |
+| Culture | CultureInfo | Gets the most preferred language by the user as a [CultureInfo](/dotnet/api/system.globalization.cultureinfo) |
 | DeviceFamily | string | Gets the family of used device as a `string`. Common `DeviceFamily` values include: Windows.Desktop, Windows.Mobile, Windows.Xbox, Windows.Holographic, Windows.Team, Windows.IoT. Prepare your code for other values |
 | DeviceManufacturer | string | Gets the name of device manufacturer as a `string`. The value will be empty if the device manufacturer couldn't be determined (ex: when running in a virtual machine). |
 | DeviceModel | string | Gets the model of the device as a `string`. The value will be empty if the device model couldn't be determined (ex: when running in a virtual machine). |
 | FirstUseTime | DateTime | Gets the DateTime (in UTC) that the app as first used. |
-| FirstVersionInstalled | [PackageVersion](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.PackageVersion) | Gets the first version of the app that was installed. |
+| FirstVersionInstalled | [PackageVersion](/uwp/api/Windows.ApplicationModel.PackageVersion) | Gets the first version of the app that was installed. |
 | IsFirstRun | bool | Gets a value indicating whether the app is being used for the first time since it was installed. |
 | IsAppUpdated | bool | Gets a value indicating whether the app is being used for the first time since being upgraded from an older version. |
 | LastLaunchTime | DateTime | Gets the DateTime (in UTC) that this was previously launched. |
@@ -33,8 +33,8 @@ The [SystemInformation](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.
 | LaunchCount | long | Gets the number of times the app has been launched since the last reset. |
 | LaunchTime | DateTime | Gets the DateTime (in UTC) that this instance of the app was launched. |
 | OperatingSystem | string | Gets the operating system as a `string` |
-| OperatingSystemArchitecture | [ProcessorArchitecture](https://msdn.microsoft.com/library/windows/apps/windows.system.processorarchitecture) | Gets used processor architecture as `ProcessorArchitecture` |
-| OperatingSystemVersion | [OSVersion](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.osversion) | Gets the operating system version (for example 10.0.10586.0) as `OSVersion` structure |
+| OperatingSystemArchitecture | [ProcessorArchitecture](/uwp/api/Windows.System.ProcessorArchitecture) | Gets used processor architecture as `ProcessorArchitecture` |
+| OperatingSystemVersion | [OSVersion](/dotnet/api/microsoft.toolkit.uwp.helpers.osversion) | Gets the operating system version (for example 10.0.10586.0) as `OSVersion` structure |
 | TotalLaunchCount | long | Gets the number of times the app has been launched. |
 
 ## Methods

--- a/docs/helpers/ThemeListener.md
+++ b/docs/helpers/ThemeListener.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # Theme Listener
 
-The [Theme Listener](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.helpers.themelistener) class allows you to determine the current Application Theme, and when it is changed via System Theme changes.
+The [Theme Listener](/dotnet/api/microsoft.toolkit.uwp.ui.helpers.themelistener) class allows you to determine the current Application Theme, and when it is changed via System Theme changes.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=ThemeListener)
@@ -41,7 +41,7 @@ End Sub
 
 | Property | Type | Description |
 | -- | -- | -- |
-| CurrentTheme | [ApplicationTheme](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.ApplicationTheme) | Gets or sets the Current Theme. |
+| CurrentTheme | [ApplicationTheme](/uwp/api/Windows.UI.Xaml.ApplicationTheme) | Gets or sets the Current Theme. |
 | CurrentThemeName | string | Gets the Name of the Current Theme. |
 | IsHighContrast | bool | Gets or sets a value indicating whether the current theme is high contrast. |
 

--- a/docs/helpers/Triggers.md
+++ b/docs/helpers/Triggers.md
@@ -9,19 +9,19 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 # State Triggers
 
 <!-- Describe your control -->
-A collection of custom visual [State Triggers](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.statetrigger).
+A collection of custom visual [State Triggers](/uwp/api/windows.ui.xaml.statetrigger).
 
 | Trigger | Purpose |
 | --- | --- |
-| [CompareStateTrigger](https://docs.microsoft.com/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.CompareStateTrigger) | Enables a state if the value is equal to, greater than, or less than another value |
-| [FullScreenModeStateTrigger](https://docs.microsoft.com/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.FullScreenModeStateTrigger) | Trigger for switching when in full screen mode |
-| [IsEqualStateTrigger](https://docs.microsoft.com/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.IsEqualStateTrigger) | Enables a state if the value is equal to another value |
-| [IsNotEqualStateTrigger](https://docs.microsoft.com/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.IsNotEqualStateTrigger) | Enables a state if the value is not equal to another value |
-| [IsNullOrEmptyStateTrigger](https://docs.microsoft.com/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.IsNullOrEmptyStateTrigger) | Enables a state if an Object is null or a String/IEnumerable is empty |
-| [NetworkConnectionStateTrigger](https://docs.microsoft.com/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.NetworkConnectionStateTrigger) | Trigger for switching when the network availability changes |
-| [RegexStateTrigger](https://docs.microsoft.com/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.RegexStateTrigger) | Enables a state if the regex expression is true for a given string value |
-| [UserHandPreferenceStateTrigger](https://docs.microsoft.com/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.UserHandPreferenceStateTrigger) | Trigger for switching UI based on whether the user favors their left or right hand |
-| [UserInteractionModeStateTrigger](https://docs.microsoft.com/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.UserInteractionModeStateTrigger) | Trigger for switching when the User interaction mode changes (tablet mode) |
+| [CompareStateTrigger](/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.CompareStateTrigger) | Enables a state if the value is equal to, greater than, or less than another value |
+| [FullScreenModeStateTrigger](/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.FullScreenModeStateTrigger) | Trigger for switching when in full screen mode |
+| [IsEqualStateTrigger](/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.IsEqualStateTrigger) | Enables a state if the value is equal to another value |
+| [IsNotEqualStateTrigger](/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.IsNotEqualStateTrigger) | Enables a state if the value is not equal to another value |
+| [IsNullOrEmptyStateTrigger](/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.IsNullOrEmptyStateTrigger) | Enables a state if an Object is null or a String/IEnumerable is empty |
+| [NetworkConnectionStateTrigger](/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.NetworkConnectionStateTrigger) | Trigger for switching when the network availability changes |
+| [RegexStateTrigger](/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.RegexStateTrigger) | Enables a state if the regex expression is true for a given string value |
+| [UserHandPreferenceStateTrigger](/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.UserHandPreferenceStateTrigger) | Trigger for switching UI based on whether the user favors their left or right hand |
+| [UserInteractionModeStateTrigger](/dotnet/api/Microsoft.Toolkit.Uwp.UI.Triggers.UserInteractionModeStateTrigger) | Trigger for switching when the User interaction mode changes (tablet mode) |
 
 ## CompareStateTrigger Example
 ```xml

--- a/docs/helpers/WeakEventListener.md
+++ b/docs/helpers/WeakEventListener.md
@@ -7,7 +7,7 @@ keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp
 
 # WeakEventListener
 
-The [WeakEventListener](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.helpers.weakeventlistener-3) allows the owner to be garbage collected if its only remaining link is an event handler.
+The [WeakEventListener](/dotnet/api/microsoft.toolkit.uwp.helpers.weakeventlistener-3) allows the owner to be garbage collected if its only remaining link is an event handler.
 
 ## Properties
 

--- a/docs/high-performance/Introduction.md
+++ b/docs/high-performance/Introduction.md
@@ -45,10 +45,10 @@ As the name suggests, the High Performance package contains a set of APIs that a
 
 This package makes heavy use of APIs such as:
 
-- [System.Buffers.ArrayPool<T>](https://docs.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1)
-- [System.Runtime.CompilerServices.Unsafe](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.unsafe)
-- [System.Runtime.InteropServices.MemoryMarshal](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.memorymarshal)
-- [System.Threading.Tasks.Parallel](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.parallel)
+- [System.Buffers.ArrayPool<T>](/dotnet/api/system.buffers.arraypool-1)
+- [System.Runtime.CompilerServices.Unsafe](/dotnet/api/system.runtime.compilerservices.unsafe)
+- [System.Runtime.InteropServices.MemoryMarshal](/dotnet/api/system.runtime.interopservices.memorymarshal)
+- [System.Threading.Tasks.Parallel](/dotnet/api/system.threading.tasks.parallel)
 
 If you are already familiar with these APIs or even if you're just getting started with writing high performance code in C# and want a set of well tested helpers to use in your own projects, have a look at what's included in this package to see how you can use it in your own projects!
 

--- a/docs/high-performance/MemoryOwner.md
+++ b/docs/high-performance/MemoryOwner.md
@@ -9,13 +9,13 @@ dev_langs:
 
 # MemoryOwner&lt;T>
 
-The [MemoryOwner&lt;T>](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.highperformance.buffers.memoryowner-1) is a buffer type implementing [`IMemoryOwner<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.buffers.imemoryowner-1), an embedded length property and a series of performance oriented APIs. It is essentially a lightweight wrapper around the [`ArrayPool<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1) type, with some additional helper utilities.
+The [MemoryOwner&lt;T>](/dotnet/api/microsoft.toolkit.highperformance.buffers.memoryowner-1) is a buffer type implementing [`IMemoryOwner<T>`](/dotnet/api/system.buffers.imemoryowner-1), an embedded length property and a series of performance oriented APIs. It is essentially a lightweight wrapper around the [`ArrayPool<T>`](/dotnet/api/system.buffers.arraypool-1) type, with some additional helper utilities.
 
 ## How it works
 
 `MemoryOwner<T>` has the following main features:
 
-- One of the main issues of arrays returned by the `ArrayPool<T>` APIs and of the `IMemoryOwner<T>` instances returned by the `MemoryPool<T>` APIs is that the size specified by the user is only being used as a _minum_ size: the actual size of the returned buffers might actually be greater. `MemoryOwner<T>` solves this by also storing the original requested size, so that [`Memory<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.memory-1) and [`Span<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.span-1) instances retrieved from it will never need to be manually sliced.
+- One of the main issues of arrays returned by the `ArrayPool<T>` APIs and of the `IMemoryOwner<T>` instances returned by the `MemoryPool<T>` APIs is that the size specified by the user is only being used as a _minum_ size: the actual size of the returned buffers might actually be greater. `MemoryOwner<T>` solves this by also storing the original requested size, so that [`Memory<T>`](/dotnet/api/system.memory-1) and [`Span<T>`](/dotnet/api/system.span-1) instances retrieved from it will never need to be manually sliced.
 - When using `IMemoryOwner<T>`, getting a `Span<T>` for the underlying buffer requires first to get a `Memory<T>` instance, and then a `Span<T>`. This is fairly expensive, and often unnecessary, as the intermediate `Memory<T>` might actually not be needed at all. `MemoryOwner<T>` instead has an additional `Span` property which is extremely lightweight, as it directly wraps the internal `T[]` array being rented from the pool.
 - Buffers rented from the pool are not cleared by default, which means that if they were not cleared when being previous returned to the pool, they might contain garbage data. Normally, users are required to clear these rented buffers manually, which can be verbose especially when done frequently. `MemoryOwner<T>` has a more flexible approach to this, through the `Allocate(int, AllocationMode)` API. This method not only allocates a new instance of exactly the requested size, but can also be used to specify which allocation mode to use: either the same one as `ArrayPool<T>`, or one that automatically clears the rented buffer.
 - There are cases where a buffer might be rented with a greater size than what is actually needed, and then resized afterwards. This would normally require users to rent a new buffer and copy the region of interest from the old buffer. Instead, `MemoryOwner<T>` exposes a `Slice(int, int)` API that simply return a new instance wrapping the specified area of interest. This allows to skip renting a new buffer and copying the items entirely.
@@ -79,7 +79,7 @@ Using this approach, buffers are now rented from a pool, which means that in mos
 
 There are two main issues with the code above:
 - `ArrayPool<T>` might return buffers that have a size greater than the requested one. To work around this issue, we need to return a tuple which also indicates the actual used size into our rented buffer.
-- By simply returning an array, we need to be extra careful to properly track its lifetime and to return it to the appropriate pool. We might work around this issue by using [`MemoryPool<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.buffers.memorypool-1) instead and by returning an `IMemoryOwner<T>` instance, but we still have the problem of rented buffers having a greater size than what we need. Additionally, `IMemoryOwner<T>` has some overhead when retrieving a `Span<T>` to work on, due to it being an interface, and the fact that we always need to get a `Memory<T>` instance first, and then a `Span<T>`.
+- By simply returning an array, we need to be extra careful to properly track its lifetime and to return it to the appropriate pool. We might work around this issue by using [`MemoryPool<T>`](/dotnet/api/system.buffers.memorypool-1) instead and by returning an `IMemoryOwner<T>` instance, but we still have the problem of rented buffers having a greater size than what we need. Additionally, `IMemoryOwner<T>` has some overhead when retrieving a `Span<T>` to work on, due to it being an interface, and the fact that we always need to get a `Memory<T>` instance first, and then a `Span<T>`.
 
 To solve both these issues, we can refactor this code again by using `MemoryOwner<T>`:
 
@@ -96,7 +96,7 @@ public static MemoryOwner<byte> GetBytesFromFile(string path)
 }
 ```
 
-The returned `IMemoryOwner<byte>` instance will take care of disposing the underlying buffer and returning it to the pool when its [`IDisposable.Dispose`](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable.dispose) method is invoked. We can use it to get a `Memory<T>` or `Span<T>` instance to interact with the loaded data, and then dispose the instance when we no longer need it. Additionally, all the `MemoryOwner<T>` properties (like `MemoryOwner<T>.Span`) respect the initial requested size we used, so we no longer need to manually keep track of the effective size within the rented buffer.
+The returned `IMemoryOwner<byte>` instance will take care of disposing the underlying buffer and returning it to the pool when its [`IDisposable.Dispose`](/dotnet/api/system.idisposable.dispose) method is invoked. We can use it to get a `Memory<T>` or `Span<T>` instance to interact with the loaded data, and then dispose the instance when we no longer need it. Additionally, all the `MemoryOwner<T>` properties (like `MemoryOwner<T>.Span`) respect the initial requested size we used, so we no longer need to manually keep track of the effective size within the rented buffer.
 
 ## Properties
 

--- a/docs/high-performance/ParallelHelper.md
+++ b/docs/high-performance/ParallelHelper.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # ParallelHelper
 
-The [ParallelHelper](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.highperformance.helpers.parallelhelper) contains high performance APIs to work with parallel code. It contains performance oriented methods that can be used to quickly setup and execute paralell operations over a given data set or iteration range or area.
+The [ParallelHelper](/dotnet/api/microsoft.toolkit.highperformance.helpers.parallelhelper) contains high performance APIs to work with parallel code. It contains performance oriented methods that can be used to quickly setup and execute paralell operations over a given data set or iteration range or area.
 
 ## How it works
 

--- a/docs/high-performance/Ref.md
+++ b/docs/high-performance/Ref.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # Ref&lt;T>
 
-The [Ref&lt;T>](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.highperformance.ref-1) is a stack-only type that can store a reference to a value of a specified type. It is semantically equivalent to a `ref T` value, with the difference that it can also be used as a type of field in another stack-only `struct` type. It can be used in place of proper `ref T` fields, which are currently not supported in C#.
+The [Ref&lt;T>](/dotnet/api/microsoft.toolkit.highperformance.ref-1) is a stack-only type that can store a reference to a value of a specified type. It is semantically equivalent to a `ref T` value, with the difference that it can also be used as a type of field in another stack-only `struct` type. It can be used in place of proper `ref T` fields, which are currently not supported in C#.
 
 ## How it works
 
@@ -87,7 +87,7 @@ This will compile and run fine, but the returned `ref int` will be invalid (as i
 
 # ReadOnlyRef&lt;T>
 
-The [ReadOnlyRef&lt;T>](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.highperformance.readonlyref-1) is a stack-only type that mirrors `Ref<T>`, with the exception that its constructor takes an `in T` parameter (a readonly reference), instead of a `ref T` one. Similarly, its `Value` property has a `ref readonly T` return type instead of `ref T`. 
+The [ReadOnlyRef&lt;T>](/dotnet/api/microsoft.toolkit.highperformance.readonlyref-1) is a stack-only type that mirrors `Ref<T>`, with the exception that its constructor takes an `in T` parameter (a readonly reference), instead of a `ref T` one. Similarly, its `Value` property has a `ref readonly T` return type instead of `ref T`. 
 
 ## Properties
 

--- a/docs/high-performance/SpanOwner.md
+++ b/docs/high-performance/SpanOwner.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # SpanOwner&lt;T>
 
-The [SpanOwner&lt;T>](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.highperformance.buffers.spanowner-1) is a stack-only buffer type that rents buffers from a shared memory pool. It essentially mirrors the functionality of `MemoryOwner<T>`, but as a `ref struct` type. This is particularly useful for short-lived buffers that are only used in synchronous code (that don't require `Memory<T>` instances), as well as code running in a tight loop, as creating `SpanOwner<T>` values will not require memory allocations at all.
+The [SpanOwner&lt;T>](/dotnet/api/microsoft.toolkit.highperformance.buffers.spanowner-1) is a stack-only buffer type that rents buffers from a shared memory pool. It essentially mirrors the functionality of `MemoryOwner<T>`, but as a `ref struct` type. This is particularly useful for short-lived buffers that are only used in synchronous code (that don't require `Memory<T>` instances), as well as code running in a tight loop, as creating `SpanOwner<T>` values will not require memory allocations at all.
 
 ## Syntax
 
@@ -23,7 +23,7 @@ byte[] buffer = new byte[length];
 // Use buffer here
 ```
 
-This is not ideal, as we're allocating a new buffer every time this code is used, and then throwing it away immediately (as mentioned in the `MemoryOwner<T>` docs as well), which puts more pressure on the garbage collector. We can optimize the code above by using [`ArrayPool<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1):
+This is not ideal, as we're allocating a new buffer every time this code is used, and then throwing it away immediately (as mentioned in the `MemoryOwner<T>` docs as well), which puts more pressure on the garbage collector. We can optimize the code above by using [`ArrayPool<T>`](/dotnet/api/system.buffers.arraypool-1):
 
 ```csharp
 // Using directive to access the ArrayPool<T> type

--- a/docs/notifications/NotificationsOverview.md
+++ b/docs/notifications/NotificationsOverview.md
@@ -14,8 +14,8 @@ Instead of having to deal with XML, you can now use Windows Community toolkit an
 
 | Documentation |
 | --- |
-| [Create Adaptive Tile](https://docs.microsoft.com/windows/uwp/design/shell/tiles-and-notifications/create-adaptive-tiles) |
-| [Sending a local Tile notification](https://docs.microsoft.com/windows/uwp/design/shell/tiles-and-notifications/sending-a-local-tile-notification) |
+| [Create Adaptive Tile](/windows/uwp/design/shell/tiles-and-notifications/create-adaptive-tiles) |
+| [Sending a local Tile notification](/windows/uwp/design/shell/tiles-and-notifications/sending-a-local-tile-notification) |
 
 ### Sample Output
 
@@ -25,8 +25,8 @@ Instead of having to deal with XML, you can now use Windows Community toolkit an
 
 | Documentation |
 | --- |
-| [Interactive Toast Notifications](https://docs.microsoft.com/windows/uwp/design/shell/tiles-and-notifications/adaptive-interactive-toasts) |
-| [Send a local toast](https://docs.microsoft.com/windows/uwp/design/shell/tiles-and-notifications/send-local-toast)
+| [Interactive Toast Notifications](/windows/uwp/design/shell/tiles-and-notifications/adaptive-interactive-toasts) |
+| [Send a local toast](/windows/uwp/design/shell/tiles-and-notifications/send-local-toast)
 
 ### Sample Output
 
@@ -34,7 +34,7 @@ Instead of having to deal with XML, you can now use Windows Community toolkit an
 
 ### Sending toasts from Win32 C# apps
 
-If you're developing a non-UWP C# app for Windows, the Windows Community toolkit makes it easier to send an interactive toast notification from your Win32 C# app. To learn more, see [Send a local toast notification from desktop C# apps](https://docs.microsoft.com/en-us/windows/uwp/design/shell/tiles-and-notifications/send-local-toast-desktop).
+If you're developing a non-UWP C# app for Windows, the Windows Community toolkit makes it easier to send an interactive toast notification from your Win32 C# app. To learn more, see [Send a local toast notification from desktop C# apps](/windows/uwp/design/shell/tiles-and-notifications/send-local-toast-desktop).
 
 ## Requirements
 
@@ -49,4 +49,4 @@ If you're developing a non-UWP C# app for Windows, the Windows Community toolkit
 
 ## Related Topics
 
-* [Toast Notification UX Guidance](https://docs.microsoft.com/windows/uwp/design/shell/tiles-and-notifications/toast-ux-guidance)
+* [Toast Notification UX Guidance](/windows/uwp/design/shell/tiles-and-notifications/toast-ux-guidance)

--- a/docs/parsers/MarkdownParser.md
+++ b/docs/parsers/MarkdownParser.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # Markdown Parser
 
-The [MarkdownDocument](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.parsers.markdown.markdowndocument) class allows you to parse a Markdown String into a Markdown Document, and then Render it with a Markdown Renderer.
+The [MarkdownDocument](/dotnet/api/microsoft.toolkit.parsers.markdown.markdowndocument) class allows you to parse a Markdown String into a Markdown Document, and then Render it with a Markdown Renderer.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=Markdown%20Parser)

--- a/docs/parsers/RSSParser.md
+++ b/docs/parsers/RSSParser.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # RSS Parser
 
-The [RssParser](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.parsers.rss.rssparser) class allows you to parse an RSS content String into an RSS Schema.
+The [RssParser](/dotnet/api/microsoft.toolkit.parsers.rss.rssparser) class allows you to parse an RSS content String into an RSS Schema.
 
 > [!div class="nextstepaction"]
 > [Try it in the sample app](uwpct://Helpers?sample=RSS%20Parser)

--- a/docs/platform-specific/PlatformSpecificAnalyzer.md
+++ b/docs/platform-specific/PlatformSpecificAnalyzer.md
@@ -10,7 +10,7 @@ dev_langs:
 
 # Platform Specific Analyzer
 
-When writing [version](https://docs.microsoft.com/windows/uwp/debug-test-perf/version-adaptive-code) or platform adaptive code, the developers should ensure that code checks for presence of API before calling it.
+When writing [version](/windows/uwp/debug-test-perf/version-adaptive-code) or platform adaptive code, the developers should ensure that code checks for presence of API before calling it.
 The platform specific analyzer is a Roslyn Analyzer that can parse through code and suggest fixes where appropriate.
 
 > [!div class="nextstepaction"]
@@ -53,4 +53,4 @@ You can [see this in action](uwpct://Helpers?sample=PlatformSpecificAnalyzer) in
 
 ## Related Topics
 
-* [Platform Specific Differences Generator](https://docs.microsoft.com/en-us/windows/communitytoolkit/platform-specific/platformspecificdifferencesgenerator)
+* [Platform Specific Differences Generator](./platformspecificdifferencesgenerator.md)

--- a/docs/services/MicrosoftGraph.md
+++ b/docs/services/MicrosoftGraph.md
@@ -39,8 +39,8 @@ To authenticate your app, you need to register your app with Azure AD, and provi
 ### Register the App to use Azure AD v1 Endpoint
 
 You can register your app manually by using the [Azure Management Portal](http://portal.azure.com), or by using Visual Studio:
-1. To register your app by using Visual Studio, see [Using Visual Studio to register your app and add Office 365 APIs.](https://msdn.microsoft.com/office/office365/HowTo/adding-service-to-your-Visual-Studio-project)
-2. To register your app manually, see [Manually register your app with Azure AD so it can access Office 365 APIs.](https://msdn.microsoft.com/en-us/office/office365/howto/add-common-consent-manually). Here is a summary to register your App manually:
+1. To register your app by using Visual Studio, see [Using Visual Studio to register your app and add Office 365 APIs.](/previous-versions/office/office-365-api/)
+2. To register your app manually, see [Manually register your app with Azure AD so it can access Office 365 APIs.](/previous-versions/office/office-365-api/). Here is a summary to register your App manually:
     - Go to the [Azure Management Portal](http://portal.azure.com)
     - Go to the "Azure Active Directory" option
     - Go to "App Registrations" option
@@ -82,7 +82,7 @@ Using MSAL, v2 (default) authentication, you can use the same App ID to paste to
 If you don't have one, you need to create an Office 365 Developer Site. There are several ways to create one:
 
 * [An MSDN subscription](https://msdn.microsoft.com/subscriptions/manage/default.aspx) - This is available to MSDN subscribers with Visual Studio Ultimate and Visual Studio Premium.
-* [An existing Office 365 subscription](https://msdn.microsoft.com/library/2ec857d5-dc6f-4cf6-ba45-adc845ef2a25%28Office.15%29.aspx) - You can use an existing Office 365 subscription, which can be any of the following: Office 365 Midsize Business, Office 365 Enterprise, Office 365 Education, Office 365 Government.
+* [An existing Office 365 subscription](/sharepoint/dev/sp-add-ins/create-a-developer-site-on-an-existing-office-365-subscription) - You can use an existing Office 365 subscription, which can be any of the following: Office 365 Midsize Business, Office 365 Enterprise, Office 365 Education, Office 365 Government.
 * [Free O365 trial](https://portal.office.com/Signup?OfferId=6881A1CB-F4EB-4db3-9F18-388898DAF510&DL=DEVELOPERPACK&ali=1) - You can start with a free 30-day trial, or buy an Office 365 developer subscription.
 * [Free O365 Developer](http://dev.office.com/devprogram) - Or Get a One year free Office 365 Developer account
 

--- a/docs/services/OneDrive.md
+++ b/docs/services/OneDrive.md
@@ -13,7 +13,7 @@ dev_langs:
 > [!WARNING]
 > (This API is obsolete and will be removed in the future. Please use the Microsoft Graph SDK or our new providers at [https://aka.ms/wgt](https://aka.ms/wgt))
 
-The **OneDrive** Service provides an easy to use service helper for the [OneDrive Developer Platform](https://docs.microsoft.com/en-us/onedrive/developer/) that uses the [Microsoft Graph](https://developer.microsoft.com/en-us/graph/docs/concepts/overview). The new OneDrive API is REST API that brings together both personal and work accounts in a single authentication model. The OneDrive Service helps you:
+The **OneDrive** Service provides an easy to use service helper for the [OneDrive Developer Platform](/onedrive/developer/) that uses the [Microsoft Graph](/graph/overview). The new OneDrive API is REST API that brings together both personal and work accounts in a single authentication model. The OneDrive Service helps you:
 
 * Initialize and authenticate with a common set of objects
 * Access OneDrive, OneDrive for Business, SharePoint document libraries, and Office Groups, to allow your app the flexibility to read and store content in any of these locations with the same code
@@ -55,9 +55,9 @@ You will need to add:
 
 < Capability Name="privateNetworkClientServer" />
 
-to your application manifest to enable AAD authentication. Capabilities in the manifest are described in more detail in this document [Capability](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appxmanifestschema/element-capability)
+to your application manifest to enable AAD authentication. Capabilities in the manifest are described in more detail in this document [Capability](/uwp/schemas/appxpackage/appxmanifestschema/element-capability)
 
-Authentication, sign-in and permission scopes are discussed in more detail in this document, [Authorization and sign-in for OneDrive in Microsoft Graph](https://docs.microsoft.com/en-us/onedrive/developer/rest-api/getting-started/graph-oauth)
+Authentication, sign-in and permission scopes are discussed in more detail in this document, [Authorization and sign-in for OneDrive in Microsoft Graph](/onedrive/developer/rest-api/getting-started/graph-oauth)
 
 ### Testing access to the OneDrive API
 
@@ -85,7 +85,7 @@ Microsoft.Toolkit.Services.OneDrive.OneDriveService.Instance.Initialize(appClien
 ```
 
 ### Defining scopes
-More information on scopes can be found in this document [Authentication scopes](https://docs.microsoft.com/en-us/onedrive/developer/rest-api/getting-started/msa-oauth#authentication-scopes)
+More information on scopes can be found in this document [Authentication scopes](/onedrive/developer/rest-api/getting-started/msa-oauth#authentication-scopes)
 
 ```csharp
 // If the user hasn't selected a scope then set it to FilesReadAll
@@ -316,4 +316,3 @@ As a workaround, the recommended path is using _CreateCollisionOption.FailIfExis
 | --- | --- |
 | Namespace | Microsoft.Toolkit.Services |
 | NuGet package | [Microsoft.Toolkit.Services](https://www.nuget.org/packages/Microsoft.Toolkit.Services/) |
-


### PR DESCRIPTION
Monthly links cleanup.  Pointed to `live` per directions since these are similar to typos.