### PR TITLE
Add docs for SwitchPresenter

### DIFF
--- a/docs/controls/SwitchPresenter.md
+++ b/docs/controls/SwitchPresenter.md
@@ -27,7 +27,7 @@ Unlike traditional approaches of showing/hiding components within a page, the `S
                    ui:TextBoxExtensions.Regex="^[a-zA-Z]{6}$"
                    Header="Confirmation code"
                    PlaceholderText="6 letters" />
-          <TextBlock Visibility="{Binding (ui:TextBoxExtensions.IsValid), ElementName=ConfirmationCodeValidator}">Thanks for entering a valid code!</TextBlock>
+          <TextBlock Visibility="{Binding (ui:TextBoxExtensions.IsValid), ElementName=ConfirmationCodeValidator}" Text="Thanks for entering a valid code!" />
         </StackPanel>
       </controls:Case>
       <controls:Case Value="E-ticket number">
@@ -36,7 +36,7 @@ Unlike traditional approaches of showing/hiding components within a page, the `S
                    ui:TextBoxExtensions.Regex="(^\d{10}$)|(^\d{13}$)"
                    Header="E-ticket number"
                    PlaceholderText="10 or 13 numbers" />
-          <TextBlock Visibility="{Binding (ui:TextBoxExtensions.IsValid), ElementName=TicketValidator}">Thanks for entering a valid code!</TextBlock>
+          <TextBlock Visibility="{Binding (ui:TextBoxExtensions.IsValid), ElementName=TicketValidator}" Text="Thanks for entering a valid code!" />
         </StackPanel>
       </controls:Case>
       <controls:Case Value="Mileage Plan number">
@@ -46,7 +46,7 @@ Unlike traditional approaches of showing/hiding components within a page, the `S
       </controls:Case>
       <!-- You can also provide a default case if no match is found -->
       <controls:Case IsDefault="True">
-        <TextBlock>Please select a way to lookup your reservation above...</TextBlock>
+        <TextBlock Text="Please select a way to lookup your reservation above..." />
       </controls:Case>
     </controls:SwitchPresenter>
 ```

--- a/docs/controls/SwitchPresenter.md
+++ b/docs/controls/SwitchPresenter.md
@@ -1,0 +1,74 @@
+---
+title: SwitchPresenter XAML Control
+author: michael-hawker
+description: A XAML ContentPresenter which can act like a switch statement for showing different UI based on a condition.
+keywords: windows 10, uwp, windows community toolkit, uwp community toolkit, uwp toolkit, switchpresenter, contentpresenter, visibility
+dev_langs:
+  - csharp
+---
+
+# SwitchPresenter XAML Control
+
+<!-- Describe your control -->
+The [SwitchPresenter](/dotnet/api/microsoft.toolkit.uwp.ui.controls.switchpresenter) control acts like a switch statement for XAML. It allows a developer to display certain content based on the condition of another value as an alternative to managing multiple Visibility values or complex visual states.
+
+Unlike traditional approaches of showing/hiding components within a page, the `SwitchPresenter` will only load and attach the matching Case's content to the Visual Tree.
+
+> [!div class="nextstepaction"]
+> [Try it in the sample app](uwpct://controls?sample=SwitchPresenter)
+
+## Example
+
+```xaml
+    <controls:SwitchPresenter Value="{Binding SelectedItem, ElementName=Lookup}">
+      <controls:Case Value="Confirmation Code">
+        <StackPanel>
+          <TextBox Name="ConfirmationCodeValidator"
+                   ui:TextBoxExtensions.Regex="^[a-zA-Z]{6}$"
+                   Header="Confirmation code"
+                   PlaceholderText="6 letters" />
+          <TextBlock Visibility="{Binding (ui:TextBoxExtensions.IsValid), ElementName=ConfirmationCodeValidator}">Thanks for entering a valid code!</TextBlock>
+        </StackPanel>
+      </controls:Case>
+      <controls:Case Value="E-ticket number">
+        <StackPanel>
+          <TextBox Name="TicketValidator"
+                   ui:TextBoxExtensions.Regex="(^\d{10}$)|(^\d{13}$)"
+                   Header="E-ticket number"
+                   PlaceholderText="10 or 13 numbers" />
+          <TextBlock Visibility="{Binding (ui:TextBoxExtensions.IsValid), ElementName=TicketValidator}">Thanks for entering a valid code!</TextBlock>
+        </StackPanel>
+      </controls:Case>
+      <controls:Case Value="Mileage Plan number">
+        <TextBox Name="PlanValidator"
+                 Header="Mileage Plan #"
+                 PlaceholderText="Mileage Plan #" />
+      </controls:Case>
+      <!-- You can also provide a default case if no match is found -->
+      <controls:Case IsDefault="True">
+        <TextBlock>Please select a way to lookup your reservation above...</TextBlock>
+      </controls:Case>
+    </controls:SwitchPresenter>
+```
+
+## Sample Project
+
+<!-- Link to the sample page in the Windows Community Toolkit Sample App -->
+[SwitchPresenter sample page Source](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Primitives/SwitchPresenter.bind). You can [see this in action](uwpct://Controls?sample=SwitchPresenter) in [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
+
+## Requirements
+
+| Device family | Universal, MinVersion 10.0.17763 or higher   |
+| -- | -- |
+| Namespace | Microsoft.Toolkit.Uwp.UI.Controls |
+| NuGet package | [Microsoft.Toolkit.Uwp.UI.Controls.Primitives](https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/) |
+
+## API
+
+* [SwitchPresenter source code](https://github.com/Microsoft/WindowsCommunityToolkit//tree/master/Microsoft.Toolkit.Uwp.UI.Controls.Primitives/SwitchPresenter)
+
+## Related Topics
+
+* [ContentPresenter](/uwp/api/Windows.UI.Xaml.Controls.ContentPresenter)
+* [VisualStateManager](/uwp/api/Windows.UI.Xaml.VisualStateManager)
+* [Visibility](/uwp/api/windows.ui.xaml.uielement.visibility)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -108,6 +108,8 @@
 
 ## [StaggeredPanel](controls/StaggeredPanel.md)
 
+## [SwitchPresenter](controls/SwitchPresenter.md)
+
 ## [TabView](controls/TabView.md)
 
 ## [TextToolbar](controls/TextToolbar.md)


### PR DESCRIPTION
## Fixes #409 
## Docs for Toolkit PR https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/3379 and https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/3789 where SwitchPresenter as added.

## What changes to the docs does this PR provide?
Adds control doc for SwitchPresenter

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Correctly picked the right branch to base the change off (`master` for new features, `live` for typos/improvements)
- [x] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/.template.md)
- [x] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/toc.md)
- [ ] Ran against a spell and grammar checker 
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
