### PR TITLE
Added EnumValuesExtensions docs page

### DIFF
--- a/docs/extensions/EnumValuesExtension.md
+++ b/docs/extensions/EnumValuesExtension.md
@@ -1,0 +1,30 @@
+---
+title: EnumValuesExtensions
+author: Sergio0694
+description: A markup extension that returns a collection of values of a specific enum type.
+keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, markup extension, XAML, markup, enum
+---
+
+# EnumValuesExtensions
+
+The [`EnumValuesExtensions`](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.EnumValuesExtensions) type implements a markup extension that returns a collection of values of a specific enum type. It can be useful to easily bind a collection of all possible values from a given enum type to a UI element such as a [`ComboBox`](https://docs.microsoft.com/windows/uwp/design/controls-and-patterns/combo-box) or some other items container or selector control.
+
+> **Platform APIs:** [`EnumValuesExtensions`](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.EnumValuesExtensions)
+
+## Syntax
+
+Assuming we had an `Animal` enum type and we wanted the user to pick one of the available names, here is the XAML syntax that allows us to create a `ComboBox` and display all `Animal` values, directly from XAML and with no code-behind:
+
+```xaml
+<ComboBox
+    xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
+    xmlns:enums="using:MyApplication.Enums"
+    ItemsSource="{ui:EnumValues Type=enums:Animal}"
+    SelectedIndex="0"/>
+```
+
+In this example we're just relying on the default `ComboBox` item template, that will display the name of each `Animal` value in a [`TextBlock`](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.textblock) control. We could of course also define a custom item template if we wanted to show additional info for each individual `Animal` value, or if we wanted to further customize how each value is presented to the user.
+
+## Examples
+
+You can find more examples in the [unit tests](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/UnitTests).

--- a/docs/extensions/EnumValuesExtension.md
+++ b/docs/extensions/EnumValuesExtension.md
@@ -7,9 +7,9 @@ keywords: windows 10, uwp, uwp community toolkit, uwp toolkit, markup extension,
 
 # EnumValuesExtensions
 
-The [`EnumValuesExtensions`](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.EnumValuesExtensions) type implements a markup extension that returns a collection of values of a specific enum type. It can be useful to easily bind a collection of all possible values from a given enum type to a UI element such as a [`ComboBox`](https://docs.microsoft.com/windows/uwp/design/controls-and-patterns/combo-box) or some other items container or selector control.
+The [`EnumValuesExtensions`](/dotnet/api/microsoft.toolkit.uwp.ui.EnumValuesExtensions) type implements a markup extension that returns a collection of values of a specific enum type. It can be useful to easily bind a collection of all possible values from a given enum type to a UI element such as a [`ComboBox`](/windows/uwp/design/controls-and-patterns/combo-box) or some other items container or selector control.
 
-> **Platform APIs:** [`EnumValuesExtensions`](https://docs.microsoft.com/dotnet/api/microsoft.toolkit.uwp.ui.EnumValuesExtensions)
+> **Platform APIs:** [`EnumValuesExtensions`](/dotnet/api/microsoft.toolkit.uwp.ui.EnumValuesExtensions)
 
 ## Syntax
 
@@ -23,8 +23,8 @@ Assuming we had an `Animal` enum type and we wanted the user to pick one of the 
     SelectedIndex="0"/>
 ```
 
-In this example we're just relying on the default `ComboBox` item template, that will display the name of each `Animal` value in a [`TextBlock`](https://docs.microsoft.com/uwp/api/windows.ui.xaml.controls.textblock) control. We could of course also define a custom item template if we wanted to show additional info for each individual `Animal` value, or if we wanted to further customize how each value is presented to the user.
+In this example we're just relying on the default `ComboBox` item template, that will display the name of each `Animal` value in a [`TextBlock`](/uwp/api/windows.ui.xaml.controls.textblock) control. We could of course also define a custom item template if we wanted to show additional info for each individual `Animal` value, or if we wanted to further customize how each value is presented to the user.
 
 ## Examples
 
-You can find more examples in the [unit tests](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/UnitTests).
+You can find more examples in the [unit tests](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/rel/7.0.0/UnitTests).

--- a/docs/extensions/HyperlinkExtensions.md
+++ b/docs/extensions/HyperlinkExtensions.md
@@ -29,4 +29,4 @@ Using the `HyperlinkExtensions` attached properties simply requires you to assig
 
 ## Examples
 
-You can find more examples in the [unit tests](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/master/UnitTests).
+You can find more examples in the [unit tests](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/rel/7.0.0/UnitTests/UnitTests.UWP/Extensions/Test_EnumValuesExtension.cs).

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -205,6 +205,8 @@
 
 ## [HyperlinkExtensions](extensions/HyperlinkExtensions.md)
 
+## [EnumValuesExtensions](extensions/EnumValuesExtensions.md)
+
 ## [IconMarkupExtensions](extensions/IconMarkupExtensions.md)
 
 ## [ListViewExtensions](extensions/ListViewExtensions.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -205,7 +205,7 @@
 
 ## [HyperlinkExtensions](extensions/HyperlinkExtensions.md)
 
-## [EnumValuesExtensions](extensions/EnumValuesExtensions.md)
+## [EnumValuesExtensions](extensions/EnumValuesExtension.md)
 
 ## [IconMarkupExtensions](extensions/IconMarkupExtensions.md)
 


### PR DESCRIPTION
## Docs for Toolkit PR \#? Can't find it right now 🤔

## What changes to the docs does this PR provide?
<!-- Please describe the updated information in detail -->
Added docs page for `EnumValuesExtension`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Correctly picked the right branch to base the change off (`master` for new features, `live` for typos/improvements)
- [X] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/.template.md)
- [X] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/toc.md)
- [X] Ran against a spell and grammar checker 
- [X] Contains **NO** breaking changes