### PR TITLE
Fixed animation archived links in ToC

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -149,15 +149,7 @@
 
 ### [Handling Failure and Down-level](animations/lottie-scenarios/fallback.md)
 
-## [Offset](animations/Offset.md)
-
-## [ReorderGridAnimation](animations/ReorderGrid.md)
-
-## [Rotate](animations/Rotate.md)
-
-## [Saturation](animations/Saturation.md)
-
-## [Scale](animations/Scale.md)
+## [ItemsReorderAnimation](animations/ItemsReorderAnimation.md)
 
 ## [ScrollViewerExtensions](animations/ScrollViewerExtensions.md)
 


### PR DESCRIPTION
## Follow up for #443

## What changes to the docs does this PR provide?
<!-- Please describe the updated information in detail -->
Added missing `ItemsReorderAnimation` docs link in ToC file, and removed duplicate archived animation docs pages from ToC.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Correctly picked the right branch to base the change off (`master` for new features, `live` for typos/improvements)
- [X] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/rel/7.0.0/docs/.template.md)
- [X] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/rel/7.0.0/docs/toc.md)
- [X] Ran against a spell and grammar checker 
- [X] Contains **NO** breaking changes