### PR TITLE
Add PreviousVersionInstalled property details

### DIFF
--- a/docs/helpers/SystemInformation.md
+++ b/docs/helpers/SystemInformation.md
@@ -27,6 +27,7 @@ The [SystemInformation](/dotnet/api/microsoft.toolkit.uwp.helpers.systeminformat
 | DeviceModel | string | Gets the model of the device as a `string`. The value will be empty if the device model couldn't be determined (ex: when running in a virtual machine). |
 | FirstUseTime | DateTime | Gets the DateTime (in UTC) that the app as first used. |
 | FirstVersionInstalled | [PackageVersion](/uwp/api/Windows.ApplicationModel.PackageVersion) | Gets the first version of the app that was installed. |
+| PreviousVersionInstalled | [PackageVersion](/uwp/api/Windows.ApplicationModel.PackageVersion) | Gets the previous version of the app that was installed. |
 | Instance | SystemInformation | Gets public singleton property. |
 | IsFirstRun | bool | Gets a value indicating whether the app is being used for the first time since it was installed. |
 | IsAppUpdated | bool | Gets a value indicating whether the app is being used for the first time since being upgraded from an older version. |


### PR DESCRIPTION
## Docs for Toolkit PR 
[#](https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/4000

## What changes to the docs does this PR provide?
Add "PreviousVersionInstalled" to SystemInformation #4000

## PR Checklist
- [x] Correctly picked the right branch to base the change off (`master` for new features, `live` for typos/improvements)
- [x] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/rel/7.0.0/docs/toc.md)
- [x] Ran against a spell and grammar checker 
- [x] Contains **NO** breaking changes