### PR TITLE
Fix Guard source code link

### DIFF
--- a/docs/developer-tools/Guard.md
+++ b/docs/developer-tools/Guard.md
@@ -133,4 +133,4 @@ The Guard class supports .NET Standard
 
 ## API
 
-- [Guard source code](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/rel/7.0.0/Microsoft.Toolkit/Diagnostics)
+- [Guard source code](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/rel/7.0.0/Microsoft.Toolkit.Diagnostics)


### PR DESCRIPTION
## What changes to the docs does this PR provide?
Fixes the link to the Guard source code

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Correctly picked the right branch to base the change off (`dev` for new features, `master` for typos/improvements)
- [ ] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/rel/7.0.0/docs/.template.md)
- [ ] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/rel/7.0.0/docs/toc.md)
- [ ] Ran against a spell and grammar checker 
- [x] Contains **NO** breaking changes
