### PR TITLE
Hiding preview Graph docs in toc

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -93,7 +93,7 @@
 
 ### [ProviderExtensions](graph/helpers/ProviderExtensions.md)
 
-### RoamingSettingsHelper (Coming soon!)
+<!-- ### RoamingSettingsHelper (Coming soon!)
 
 ## Controls
 
@@ -103,7 +103,7 @@
 
 ### [PersonView (Preview)](graph/controls/PersonView.md)
 
-### [PeoplePicker (Preview)](graph/controls/PeoplePicker.md)
+### [PeoplePicker (Preview)](graph/controls/PeoplePicker.md) -->
 
 # WinUI 3
 


### PR DESCRIPTION
Some of the preview content is not fully up to date and was requested that we remove until made current. In this PR I commented out a few lines from the toc to hide the following preview content:
- RoamingSettingsHelper
- GraphPresenter
- LoginButton
- PersonView
- PeoplePicker

These can be uncommented in the future once updates have been made.