### PR TITLE
Graph doc updates post bug bash

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -3,12 +3,27 @@
       {
         "source_path": "archive/graph/providers/InteractiveProviderBehavior.md",
         "redirect_url": "/graph/providers/interactiveproviderbehavior",
-        "redirect_document_id": false
+        "redirect_document_id": true
       },
       {
         "source_path": "archive/graph/providers/MockProviderBehavior.md",
         "redirect_url": "/graph/providers/mockproviderbehavior",
-        "redirect_document_id": false
+        "redirect_document_id": true
+      },
+      {
+        "source_path": "graph/authentication/msal.md",
+        "redirect_url": "/graph/authentication/msalprovider",
+        "redirect_document_id": true
+      },
+      {
+        "source_path": "graph/authentication/windows.md",
+        "redirect_url": "/graph/authentication/windowsprovider",
+        "redirect_document_id": true
+      },
+      {
+        "source_path": "graph/authentication/custom.md",
+        "redirect_url": "/graph/authentication/iprovider",
+        "redirect_document_id": true
       }
     ]
 }

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1,0 +1,14 @@
+{
+    "redirections": [
+      {
+        "source_path": "archive/graph/providers/InteractiveProviderBehavior.md",
+        "redirect_url": "/graph/providers/interactiveproviderbehavior",
+        "redirect_document_id": false
+      },
+      {
+        "source_path": "archive/graph/providers/MockProviderBehavior.md",
+        "redirect_url": "/graph/providers/mockproviderbehavior",
+        "redirect_document_id": false
+      }
+    ]
+}

--- a/docs/archive/graph/providers/InteractiveProviderBehavior.md
+++ b/docs/archive/graph/providers/InteractiveProviderBehavior.md
@@ -10,7 +10,7 @@ dev_langs:
 # InteractiveProviderBehavior XAML Behavior
 
 > [!WARNING]
-> This API has been removed. For the latest guidance on using the Microsoft Graph in the Toolkit check out the [Windows Community Toolkit - Graph Helpers and Controls](../overview.md).
+> This API has been removed. For the latest guidance on using the Microsoft Graph in the Toolkit check out the [Windows Community Toolkit - Graph Helpers and Controls](../../../graph/overview.md).
 
 The [InteractiveProviderBehavior](/dotnet/api/microsoft.toolkit.graph.providers.interactiveproviderbehavior) provides a quick and easy way to connect to the Microsoft Identity platform and Microsoft Graph.  It is built on top of the Graph SDK's authentication providers, but allows usage from XAML.
 

--- a/docs/archive/graph/providers/MockProviderBehavior.md
+++ b/docs/archive/graph/providers/MockProviderBehavior.md
@@ -10,7 +10,7 @@ dev_langs:
 # MockProviderBehavior XAML Behavior
 
 > [!WARNING]
-> This API has been removed. For the latest guidance on using the Microsoft Graph in the Toolkit check out the [Windows Community Toolkit - Graph Helpers and Controls](../overview.md).
+> This API has been removed. For the latest guidance on using the Microsoft Graph in the Toolkit check out the [Windows Community Toolkit - Graph Helpers and Controls](../../../graph/overview.md).
 
 <!-- Describe your control -->
 The [MockProviderBehavior](/dotnet/api/microsoft.toolkit.graph.providers.mockproviderbehavior) provides sample data from the Microsoft Graph for demonstration and learning purposes only.

--- a/docs/graph/authentication/ProviderManager.md
+++ b/docs/graph/authentication/ProviderManager.md
@@ -16,35 +16,6 @@ The ProviderManager manages access to the globally configured [IProvider](./IPro
 > [!IMPORTANT]
 > Windows Community Toolkit - Graph Controls and Helpers packages are in preview. To get started using WCT preview packages visit the [WCT Preview Packages wiki page](https://aka.ms/wct/wiki/previewpackages).
 
-## Set the GlobalProvider
-
-```csharp
-using CommunityToolkit.Authentication;
-
-ProviderManager.Instance.GlobalProvider = new WindowsProvider();
-```
-
-## Listen for changes to the GlobalProvider
-
-```csharp
-using CommunityToolkit.Authentication;
-
-ProviderManager.Instance.ProviderUpdated += OnProviderUpdated;
-
-void OnProviderUpdated(object sender, ProviderUpdatedEventArgs e)
-{
-    if (e.Reason == ProviderManagerChangedState.ProviderUpdated)
-    {
-        // The GlobalProvider has been set.
-    }
-
-    if (e.Reason == ProviderManagerChangedState.ProviderStateChanged)
-    {
-        // The GlobalProvider state has changed.
-    }
-}
-```
-
 ## Properties
 
 | Property | Type | Description |

--- a/docs/graph/authentication/ProviderManager.md
+++ b/docs/graph/authentication/ProviderManager.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # ProviderManager
 
-The ProviderManager manages access to the globally configured [IProvider](./IProvider.md) instance and any state change events as users sign in and out.
+The ProviderManager manages access to the globally configured [IProvider](./custom.md) instance and any state change events as users sign in and out.
 
 > Available in the `CommunityToolkit.Authentication` package.
 
@@ -38,5 +38,5 @@ The ProviderManager manages access to the globally configured [IProvider](./IPro
 
 | Name | Description |
 | -- | -- |
-| ProviderStateChanged | The [IProvider](./IProvider.md) state has changed.|
-| ProviderUpdated | The [IProvider](./IProvider.md) itself has changed. |
+| ProviderStateChanged | The IProvider state has changed.|
+| ProviderUpdated | The IProvider instance itself has changed. |

--- a/docs/graph/authentication/ProviderManager.md
+++ b/docs/graph/authentication/ProviderManager.md
@@ -26,17 +26,20 @@ The ProviderManager manages access to the globally configured [IProvider](./cust
 
 | Event | Type | Description |
 | -- | -- | -- |
-| ProviderUpdated | EventHandler&lt;ProviderUpdatedEventArgs&gt; | Event called when the IProvider changes. |
+| ProviderUpdated | EventHandler&lt;IProvider&gt; | Event called when the IProvider changes. |
+| ProviderStateChanged | EventHandler&lt;ProviderStateChangedEventArgs&gt; | Event called when the IProvider changes. |
 
-## ProviderUpdatedEventArgs Object
+## ProviderStateChangedEventArgs Object
 
 | Property | Type | Description |
 | -- | -- | -- |
-| Reason | ProviderManagerChangedState | Gets the reason for the provider update. |
+| OldState | ProviderState | Gets the previous state of the IProvider.
+| NewState | ProviderState | Gets the new state of the IProvider.
 
-## ProviderManagerChangedState Enum
+## ProviderState Enum
 
 | Name | Description |
 | -- | -- |
-| ProviderStateChanged | The IProvider state has changed.|
-| ProviderUpdated | The IProvider instance itself has changed. |
+| Loading | The user's status is not known. |
+| SignedOut | The user is signed-out. |
+| SignedIn | The user is signed-in. |

--- a/docs/graph/authentication/ProviderManager.md
+++ b/docs/graph/authentication/ProviderManager.md
@@ -57,16 +57,6 @@ void OnProviderUpdated(object sender, ProviderUpdatedEventArgs e)
 | -- | -- | -- |
 | ProviderUpdated | EventHandler&lt;ProviderUpdatedEventArgs&gt; | Event called when the IProvider changes. |
 
-## Methods
-
-| Method | Arguments | Returns | Description |
-| -- | -- | -- | -- |
-| AuthenticateRequestAsync | HttpRequestMessage | Task | Authenticate an outgoing request. |
-| GetTokenAsync | bool silentOnly = true | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
-| SignInAsync | | Task | Sign in a user. |
-| SignOutAsync | | Task | Sign out the current user. |
-| TrySilentSignInAsync | | Task&lt;bool&gt; | Try signing in silently, without prompts. |
-
 ## ProviderUpdatedEventArgs Object
 
 | Property | Type | Description |

--- a/docs/graph/authentication/custom.md
+++ b/docs/graph/authentication/custom.md
@@ -7,9 +7,13 @@ dev_langs:
   - csharp
 ---
 
-# IProvider
+# Custom provider
 
-The `IProvider` is the base interface for creating authentication providers that work with the various controls and helpers in the toolkit. Handle authenticaiton with one of our premade `IProvider` implementations or create your own.
+If you have existing authentication code in your application, you can create a custom provider to enable authentication and access to Microsoft Graph for the toolkit's Graph based controls and helpers. To bring your own authentication provider logic, start by extending `IProvider`.
+
+## IProvider
+
+`IProvider` is the base interface for creating authentication providers that work with the various controls and helpers in the toolkit. Handle authenticaiton with one of our premade `IProvider` implementations or create your own.
 
 > Available in the `CommunityToolkit.Authentication` package.
 
@@ -19,47 +23,31 @@ The `IProvider` is the base interface for creating authentication providers that
 ```csharp
 using CommunityToolkit.Authentication;
 
-IProvider provider = ProviderManager.Instance.GlobalProvider;
+// Create an instance of your custom IProvider implementation.
+IProvider customProvider = new CustomProvider(); 
 
-if (provider?.State == ProviderState.SignedIn)
-{
-    // You are now signed in and can request access tokens.
-}
+// Set the global provider using the custom instance.
+ProviderManager.Instance.GlobalProvider = customProvider;
 ```
 
-## Properties
+### Properties
 
 | Property | Type | Description |
 | -- | -- | -- |
 | State | ProviderState | Gets the current authentication state of the provider. |
 
-## Events
+### Events
 
 | Event | Type | Description |
 | -- | -- | -- |
 | StateChanged | EventHandler&lt;ProviderStateChangedEventArgs&gt; | An event that is called whenever the login state changes.
 
-## Methods
+### Methods
 
 | Method | Arguments | Returns | Description |
 | -- | -- | -- | -- |
 | AuthenticateRequestAsync | HttpRequestMessage | Task | Authenticate an outgoing request. |
-| GetTokenAsync | bool silentOnly = true | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
+| GetTokenAsync | bool silentOnly = false, string[] scopes = null | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
 | SignInAsync | | Task | Sign in a user. |
 | SignOutAsync | | Task | Sign out the current user. |
 | TrySilentSignInAsync | | Task&lt;bool&gt; | Try signing in silently, without prompts. |
-
-## ProviderStateChangedEventArgs Object
-
-| Property | Type | Description |
-| -- | -- | -- |
-| OldState | ProviderState | Gets the previous state of the IProvider.
-| NewState | ProviderState | Gets the new state of the IProvider.
-
-## ProviderState Enum
-
-| Name | Description |
-| -- | -- |
-| Loading | The user's status is not known. |
-| SignedOut | The user is signed-out. |
-| SignedIn | The user is signed-in. |

--- a/docs/graph/authentication/custom.md
+++ b/docs/graph/authentication/custom.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # IProvider
 
-The IProvider is the base interface for creating authentication providers that work with the various controls and helpers in the toolkit.
+The `IProvider` is the base interface for creating authentication providers that work with the various controls and helpers in the toolkit. Handle authenticaiton with one of our premade `IProvider` implementations or create your own.
 
 > Available in the `CommunityToolkit.Authentication` package.
 

--- a/docs/graph/authentication/msal.md
+++ b/docs/graph/authentication/msal.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # MsalProvider
 
-The MsalProvider is an [IProvider](./IProvider.md) implementation built on the official Microsoft Authentication Library (MSAL). It is NetStandard 2.0 so it works in both UWP and WPF apps.
+The MsalProvider is an [IProvider](./custom.md) implementation built on the official Microsoft Authentication Library (MSAL). It is NetStandard 2.0 so it works in both UWP and WPF apps.
 
 > Available in the `CommunityToolkit.Authentication.Msal` package.
 
@@ -49,13 +49,13 @@ This lets administrators who acquire the app for their organization grant consen
 
 | Property | Type | Description |
 | -- | -- | -- |
-| State | [ProviderState](./IProvider.md) | Gets the current authentication state of the provider. |
+| State | ProviderState | Gets the current authentication state of the provider. |
 
 ## Events
 
 | Event | Type | Description |
 | -- | -- | -- |
-| StateChanged | EventHandler&lt;[ProviderStateChangedEventArgs](./IProvider.md)&gt; | Event called when the provider state changes. |
+| StateChanged | EventHandler&lt;ProviderStateChangedEventArgs&gt; | Event called when the provider state changes. |
 
 ## Methods
 

--- a/docs/graph/authentication/msal.md
+++ b/docs/graph/authentication/msal.md
@@ -27,23 +27,19 @@ ProviderManager.Instance.GlobalProvider = new MsalProvider(clientId, scopes);
 
 ## Prerequisite Configure Client Id in Partner Center
 
-If your product integrates with Azure AD and calls APIs that request either application permissions or delegated permissions that require administrator consent, you will also need to enter your Azure AD Client ID in Partner Center:
-
-`https://partner.microsoft.com/dashboard/products/&lt;YOUR-APP-ID&gt;/administrator-consent`
-
-This lets administrators who acquire the app for their organization grant consent for your product to act on behalf of all users in the tenant.
-
-> [!NOTE]
-> You only need to specify the client id if you need admin consent for delegated permissions from your AAD app registration. Simple authentication for public accounts does not require a client id or any additional configuration.
-
 > [!IMPORTANT]
-> Be sure to Register Client Id in Azure first following the guidance here: [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
+> To obtain a Client Id, first register your app in Azure following the guidance here: Quickstart: Register an application with the Microsoft identity platform
 >
-> After finishing the initial registration page, you will also need to add an additional redirect URI. Click on "Add a Redirect URI" and add the value retrieved from running `WindowsProvider.RedirectUri`.
->
-> You'll also want to set the toggle to true for "Allow public client flows".
->
-> Then click "Save".
+> After finishing the initial registration, you will also need to add an additional redirect URI. Click on "Authentication -> Add a Platform", select "Mobile and desktop applications", and check the "https://login.microsoftonline.com/common/oauth2/nativeclient" checkbox on that page. Then click "Configure".
+
+## Constructor
+
+| Parameter | Type | Default | Description |
+| -- | -- | -- | -- |
+| clientId | string | | Registered client id. |
+| scopes | string[] | null | Listof scopes to initially request. | 
+| redirectUri | string | `https://login.microsoftonline.com/common/oauth2/nativeclient` | Redirect URI for authentication response. |
+| autoSignIn | bool | true | Determines whether the provider attempts to silently log in upon instantiation. |
 
 ## Properties
 

--- a/docs/graph/authentication/msal.md
+++ b/docs/graph/authentication/msal.md
@@ -37,7 +37,7 @@ ProviderManager.Instance.GlobalProvider = new MsalProvider(clientId, scopes);
 | Parameter | Type | Default | Description |
 | -- | -- | -- | -- |
 | clientId | string | | Registered client id. |
-| scopes | string[] | null | Listof scopes to initially request. | 
+| scopes | string[] | null | Listof scopes to initially request. |
 | redirectUri | string | `https://login.microsoftonline.com/common/oauth2/nativeclient` | Redirect URI for authentication response. |
 | autoSignIn | bool | true | Determines whether the provider attempts to silently log in upon instantiation. |
 

--- a/docs/graph/authentication/msal.md
+++ b/docs/graph/authentication/msal.md
@@ -57,7 +57,7 @@ ProviderManager.Instance.GlobalProvider = new MsalProvider(clientId, scopes);
 
 | Method | Arguments | Returns | Description |
 | -- | -- | -- | -- |
-| GetTokenAsync | bool silentOnly = true | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
+| GetTokenAsync | bool silentOnly = false, string[] scopes = null | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
 | AuthenticateRequestAsync | HttpRequestMessage | Task | Authenticate an outgoing request. |
 | SignInAsync | | Task | Sign in a user. |
 | SignOutAsync | | Task | Sign out the current user. |

--- a/docs/graph/authentication/msal.md
+++ b/docs/graph/authentication/msal.md
@@ -28,7 +28,7 @@ ProviderManager.Instance.GlobalProvider = new MsalProvider(clientId, scopes);
 ## Prerequisite Configure Client Id in Partner Center
 
 > [!IMPORTANT]
-> To obtain a Client Id, first register your app in Azure following the guidance here: Quickstart: Register an application with the Microsoft identity platform
+> To obtain a Client Id, first register your app in Azure following the guidance here: [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
 >
 > After finishing the initial registration, you will also need to add an additional redirect URI. Click on "Authentication -> Add a Platform", select "Mobile and desktop applications", and check the "https://login.microsoftonline.com/common/oauth2/nativeclient" checkbox on that page. Then click "Configure".
 

--- a/docs/graph/authentication/overview.md
+++ b/docs/graph/authentication/overview.md
@@ -120,7 +120,7 @@ Once authenticated, you can now make API calls to Microsoft Graph using the Grap
 ### Use the Graph SDK 
 
 Access APIs using the Graph SDK through a preconfigured `GraphServiceClient` available through an extension method on `IProvider` called, `GetClient()`.
-See [ProviderExtensions](../helpers/ProviderExtensions.md) for more details.
+See [Microsoft Graph Extensions](../helpers/extensions.md) for more details.
 
 This is the easiest way to get started because all of the Graph types are available and the `GraphServiceClient` offers a convenient way of building requests.
 

--- a/docs/graph/authentication/overview.md
+++ b/docs/graph/authentication/overview.md
@@ -79,24 +79,22 @@ if (ProviderManager.Instance.GlobalProvider?.State === ProviderState.SignedIn) {
 }
 ```
 
-You can also use the `ProviderUpdated` event to get notified whenever the state of the provider changes.
+You can also use the `ProviderUpdated` and `ProviderStateChanged` events to get notified whenever provider is set or changes state.
 
 ```csharp
 using CommunityToolkit.Authentication;
 
 ProviderManager.Instance.ProviderUpdated += OnProviderUpdated;
+ProviderManager.Instance.ProviderStateChanged += OnProviderStateChanged;
 
-void OnProviderUpdated(object sender, ProviderUpdatedEventArgs e)
+void OnProviderUpdated(object sender, IProvider provider)
 {
-    if (e.Reason == ProviderManagerChangedState.ProviderUpdated)
-    {
-        // The GlobalProvider has been set or unset.
-    }
+    // The global provider has been set.
+}
 
-    if (e.Reason == ProviderManagerChangedState.ProviderStateChanged)
-    {
-        // The GlobalProvider state has changed.
-    }
+void OnProviderStateChanged(object sender, ProviderUpdatedEventArgs args)
+{
+    // The state of the global provider has changed.
 }
 ```
 

--- a/docs/graph/authentication/overview.md
+++ b/docs/graph/authentication/overview.md
@@ -16,19 +16,19 @@ Authentication is always the first step to working with Microsoft Graph. The too
 
 You can use the providers on their own, without components, to quickly implement authentication for your app and make calls to Microsoft Graph via the Microsoft Graph .NET SDK.
 
-The providers are required when using the Microsoft Graph Toolkit helpers and controls so they can access Microsoft Graph APIs. If you already have your own authentication and want to use the helpers and controls, you can use a [custom provider](./IProvider.md) instead.
+The providers are required when using the Microsoft Graph Toolkit helpers and controls so they can access Microsoft Graph APIs. If you already have your own authentication and want to use the helpers and controls, you can use a [custom provider](./custom.md) instead.
 
 The tookit includes the following providers:
 
 | Providers | Description |
 | -- | -- |
-| [Msal](./MsalProvider.md) | Uses MSAL for .NET to sign in users and acquire tokens to use with Microsoft Graph in a NetStandard 2.0 application. |
-| [Windows](./WindowsProvider.md) | Uses native WebAccountManager (WAM) APIs to sign in users and acquire tokens to use with Microsoft Graph in a UWP application. |
-| [Custom](./IProvider.md)Custom | Create a custom provider to enable authentication and access to Microsoft Graph with your application's existing authentication code. |
+| [Msal](./msal.md) | Uses MSAL for .NET to sign in users and acquire tokens to use with Microsoft Graph in a NetStandard 2.0 application. |
+| [Windows](./windows.md) | Uses native WebAccountManager (WAM) APIs to sign in users and acquire tokens to use with Microsoft Graph in a UWP application. |
+| [Custom](./custom.md)Custom | Create a custom provider to enable authentication and access to Microsoft Graph with your application's existing authentication code. |
 
 ## Initializing the GlobalProvider
 
-To use an authentication provider in your app, you need to set it as the global provider. The [ProviderManager](./ProviderManager.md) is the singleton that stores the globally accessible [IProvider](./IProvider.md) implementation and signals events in response to authentication state changes.
+To use an authentication provider in your app, you need to set it as the global provider. The [ProviderManager](./ProviderManager.md) is the singleton that stores the globally accessible [IProvider](./custom.md) implementation and signals events in response to authentication state changes.
 Set the `GlobalProvider` property at app startup and any other Graph based code will respond to any changes as users sign in and out.
 
 ```csharp
@@ -53,7 +53,7 @@ ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes);
 
 ### ProviderState
 
-The providers keeps track of the user's authentication state and communicate it outwards. For example, when a user successfully signs in, the ProviderState is updated to SignedIn, signaling to the application that it is now able to make calls to Microsoft Graph.
+The providers keeps track of the user's authentication state and communicate it outwards. For example, when a user successfully signs in, the `ProviderState` is updated to `SignedIn`, signaling to the application that it is now able to make calls to Microsoft Graph.
 
 ```csharp
 public enum ProviderState
@@ -79,7 +79,7 @@ if (ProviderManager.Instance.GlobalProvider?.State === ProviderState.SignedIn) {
 }
 ```
 
-You can also use the ProviderUpdated event to get notified whenever the state of the provider changes.
+You can also use the `ProviderUpdated` event to get notified whenever the state of the provider changes.
 
 ```csharp
 using CommunityToolkit.Authentication;
@@ -102,7 +102,7 @@ void OnProviderUpdated(object sender, ProviderUpdatedEventArgs e)
 
 ## Getting an access token
 
-Each provider exposes a function called getTokenAsync that can retrieve the current access token or retrieve a new access token for the provided scopes. The following example shows how to get a new access token or the currently signed in user:
+Each provider exposes a function called `getTokenAsync` that can retrieve the current access token or retrieve a new access token for the provided scopes. The following example shows how to get a new access token or the currently signed in user:
 
 ```csharp
 using CommunityToolkit.Authentication;
@@ -119,10 +119,10 @@ Once authenticated, you can now make API calls to Microsoft Graph using the Grap
 
 ### Use the Graph SDK 
 
-Access APIs using the Graph SDK through a preconfigured GraphServiceClient available through an extension method on IProvider called, `GetClient()`.
+Access APIs using the Graph SDK through a preconfigured `GraphServiceClient` available through an extension method on `IProvider` called, `GetClient()`.
 See [ProviderExtensions](../helpers/ProviderExtensions.md) for more details.
 
-This is the easiest way to get started because all of the Graph types are available and the GraphServiceClient offers a convenient way of building requests.
+This is the easiest way to get started because all of the Graph types are available and the `GraphServiceClient` offers a convenient way of building requests.
 
 Available in the `CommunityToolkit.Graph` package.
 

--- a/docs/graph/authentication/overview.md
+++ b/docs/graph/authentication/overview.md
@@ -115,9 +115,9 @@ string token = await provider.GetTokenAsync(silentOnly: false);
 
 ## Call Microsoft Graph APIs
 
-Once authenticated, you can now make API calls to Microsoft Graph using the Graph SDK or without. 
+Once authenticated, you can now make API calls to Microsoft Graph using the Graph SDK or without.
 
-### Use the Graph SDK 
+### Use the Graph SDK
 
 Access APIs using the Graph SDK through a preconfigured `GraphServiceClient` available through an extension method on `IProvider` called, `GetClient()`.
 See [Microsoft Graph Extensions](../helpers/extensions.md) for more details.

--- a/docs/graph/authentication/overview.md
+++ b/docs/graph/authentication/overview.md
@@ -54,7 +54,9 @@ void OnProviderChanged (object sender, ProviderUpdatedEventArgs args)
 ### MsalProvider
 
 An [IProvider](./IProvider.md) implementation built on the official Microsoft Authentication Library (MSAL).
-The [MsalProvider](./MsalProvider.md)  is NetStandard and supports any NetStandard 2.0 applications.
+The [MsalProvider](./MsalProvider.md) is NetStandard and supports any NetStandard 2.0 applications.
+
+Use the [MsalProvider](./MsalProvider.md) in NetStandard 2.0 applications and anywhere [MSAL for .NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) is supported.
 
 Available in the `CommunityToolkit.Authentication.Msal` package.
 
@@ -62,6 +64,8 @@ Available in the `CommunityToolkit.Authentication.Msal` package.
 
 A lightweight [IProvider](./IProvider.md) implementation built directly on the native Windows Account Manager (WAM) APIs.
 The [WindowsProvider](./WindowsProvider.md) enables authentication of consumer MSA accounts without any Azure AAD config and only requires a Microsoft Store App registration to use.
+
+Use the [WindowsProvider](./WindowsProvider.md) when working in UWP for a simple native solution that leaves out the [MSAL for .NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) SDK to minimize package size.
 
 Available in the `CommunityToolkit.Authentication.Uwp` package.
 

--- a/docs/graph/authentication/windows.md
+++ b/docs/graph/authentication/windows.md
@@ -10,7 +10,7 @@ dev_langs:
 # WindowsProvider
 
 The WindowsProvider is an authentication provider for accessing locally configured accounts on Windows.
-It extends [IProvider](./IProvider.md) and uses the native Windows AccountManager (WAM) APIs and AccountsSettingsPane for sign in.
+It extends [IProvider](./custom.md) and uses the native Windows AccountManager (WAM) APIs and AccountsSettingsPane for sign in.
 
 > Available in the `CommunityToolkit.Authentication.Uwp` package.
 
@@ -61,7 +61,7 @@ using CommunityToolkit.Authentication;
 
 // Easily create a new WindowsProvider instance and set the GlobalProvider.
 // Don't forget to associate your app with the Microsoft Store before attempting sign in.
-ProviderManager.Instance.GlobalProvider = new WindowsProvider(new string[] { "User.Read", "Task.ReadWrite" });
+ProviderManager.Instance.GlobalProvider = new WindowsProvider(new string[] { "User.Read", "Tasks.ReadWrite" });
 ```
 
 The WindowsProvider can also be configured to disabled auto-signin or show custom content in the `AccountsSettingsPane`.
@@ -106,7 +106,7 @@ ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes, accountsSe
 
 | Property | Type | Description |
 | -- | -- | -- |
-| State | [ProviderState](./IProvider.md) | Gets the current authentication state of the provider. |
+| State | ProviderState | Gets the current authentication state of the provider. |
 | Scopes | string[] | List of scopes to pre-authorize on the user during authentication. |
 | WebAccountsProviderConfig | WebAccountProviderConfig | configuration values for determining the available web account providers. |
 | AccountsSettingsPaneConfig | AccountsSettingsPaneConfig | Configuration values for the AccountsSettingsPane, shown during authentication. |
@@ -116,7 +116,7 @@ ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes, accountsSe
 
 | Event | Type | Description |
 | -- | -- | -- |
-| StateChanged | EventHandler&lt;[ProviderStateChangedEventArgs](./IProvider.md)&gt; | Event called when the provider state changes. |
+| StateChanged | EventHandler&lt;ProviderStateChangedEventArgs&gt; | Event called when the provider state changes. |
 
 ## Methods
 

--- a/docs/graph/authentication/windows.md
+++ b/docs/graph/authentication/windows.md
@@ -102,6 +102,15 @@ bool autoSignIn = false;
 ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes, accountsSettingsPaneConfig, webAccountProviderConfig, autoSignIn);
 ```
 
+## Constructor
+
+| Parameter | Type | Default | Description |
+| -- | -- | -- | -- |
+| scopes | string[] | null | List of scopes to initially request. |
+| webAccountProviderConfig | WebAccountProviderConfig? | null | Configuration value for determining the available web account providers. |
+| accountsSettingsPaneConfig | AccountsSettingsPaneConfig? | null | Configuration values for the AccountsSettingsPane. |
+| autoSignIn | bool | true | Determines whether the provider attempts to silently log in upon instantiation. |
+
 ## Properties
 
 | Property | Type | Description |

--- a/docs/graph/authentication/windows.md
+++ b/docs/graph/authentication/windows.md
@@ -66,7 +66,7 @@ ProviderManager.Instance.GlobalProvider = new WindowsProvider(new string[] { "Us
 
 The WindowsProvider can also be configured to disabled auto-signin or show custom content in the `AccountsSettingsPane`.
 Additional configuration for account types will be available via the `WebAccountProviderConfig` object in the future.
-Currently, only consumer MSA accounts are supported. 
+Currently, only consumer MSA accounts are supported.
 
 ```CSharp
 using CommunityToolkit.Authentication;

--- a/docs/graph/authentication/windows.md
+++ b/docs/graph/authentication/windows.md
@@ -66,7 +66,7 @@ ProviderManager.Instance.GlobalProvider = new WindowsProvider(new string[] { "Us
 
 The WindowsProvider can also be configured to disabled auto-signin or show custom content in the `AccountsSettingsPane`.
 Additional configuration for account types will be available via the `WebAccountProviderConfig` object in the future.
-Currently, only consumer MSA accounts are supported.
+Currently, only consumer MSA accounts are supported. 
 
 ```CSharp
 using CommunityToolkit.Authentication;
@@ -132,7 +132,7 @@ ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes, accountsSe
 | Method | Arguments | Returns | Description |
 | -- | -- | -- | -- |
 | AuthenticateRequestAsync | HttpRequestMessage | Task | Authenticate an outgoing request. |
-| GetTokenAsync | bool silentOnly = true | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
+| GetTokenAsync | bool silentOnly = true, string[] scopes = null | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
 | SignInAsync | | Task | Sign in a user. |
 | SignOutAsync | | Task | Sign out the current user. |
 | TrySilentSignInAsync | | Task&lt;bool&gt; | Try signing in silently, without prompts. |

--- a/docs/graph/controls/LoginButton.md
+++ b/docs/graph/controls/LoginButton.md
@@ -9,13 +9,10 @@ dev_langs:
 
 # (Preview) LoginButton XAML Control
 
-The [LoginButton](/dotnet/api/microsoft.toolkit.graph.controls.loginbutton) is both a button and flyout control to facilitate Microsoft identity platform authentication. It provides two states:
+The LoginButton is both a button and flyout control to facilitate Microsoft identity platform authentication. It provides two states:
 
 * When the user is not signed in, the control is a simple button to initiate the sign in process.
 * When the user is signed in, the control displays the current signed in user name, profile image, and email. When clicked, a flyout is opened with a command to sign out.
-
-> [!div class="nextstepaction"]
-> [Try it in the sample app](uwpct://controls?sample=LoginButton)
 
 > Available in the `CommunityToolkit.Graph.Uwp` package.
 
@@ -24,8 +21,10 @@ The [LoginButton](/dotnet/api/microsoft.toolkit.graph.controls.loginbutton) is b
 
 ## Syntax
 
-```xaml
-  <wgt:LoginButton/>
+```xml
+<Grid xmlns:controls="using:CommunityToolkit.Graph.Uwp.Controls">
+    <controls:LoginButton />
+</Grid>
 ```
 
 ## Sample Output
@@ -49,20 +48,16 @@ The [LoginButton](/dotnet/api/microsoft.toolkit.graph.controls.loginbutton) is b
 | LogoutInitiated | The user started to logout. |
 | LogoutCompleted | The user signed out. |
 
-## Sample Project
-
-[LoginButton sample page Source](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/rel/7.0.0/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/LoginButton). You can [see this in action](uwpct://Controls?sample=LoginButton) in [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
-
 ## Requirements
 
 | Device family | Universal, MinVersion or higher |
 | -- | -- |
-| Namespace | Microsoft.Toolkit.Graph.Controls |
-| NuGet package | [Microsoft.Toolkit.Graph.Controls](https://www.nuget.org/packages/Microsoft.Toolkit.Graph.Controls) |
+| Namespace | CommunityToolkit.Graph.Uwp.Controls |
+| NuGet package | [CommunityToolkit.Graph.Uwp](https://www.nuget.org/packages/CommunityToolkit.Graph.Uwp) |
 
 ## API
 
-* [LoginButton source code](https://github.com/windows-toolkit/Graph-Controls/tree/rel/7.0.0/Microsoft.Toolkit.Graph.Controls/Controls/LoginButton)
+* [LoginButton source code](https://github.com/windows-toolkit/Graph-Controls/tree/dev/7.1.0/CommunityToolkit.Graph.Uwp/Controls/LoginButton)
 
 ## Related Topics
 

--- a/docs/graph/controls/PeoplePicker.md
+++ b/docs/graph/controls/PeoplePicker.md
@@ -20,7 +20,7 @@ The PeoplePicker searches for people and renders the list of results from Micros
 
 ```xml
 <Grid xmlns:controls="using:CommunityToolkit.Graph.Uwp.Controls">
-    <controls:PeoplePicker/>
+    <controls:PeoplePicker />
 </Grid>
 ```
 

--- a/docs/graph/controls/PeoplePicker.md
+++ b/docs/graph/controls/PeoplePicker.md
@@ -9,10 +9,7 @@ dev_langs:
 
 # (Preview) PeoplePicker XAML Control
 
-The [PeoplePicker](/dotnet/api/microsoft.toolkit.graph.controls.peoplepicker) searches for people and renders the list of results from Microsoft Graph. By default, the component will search across all people.
-
-> [!div class="nextstepaction"]
-> [Try it in the sample app](uwpct://controls?sample=PeoplePicker)
+The PeoplePicker searches for people and renders the list of results from Microsoft Graph. By default, the component will search across all people.
 
 > Available in the `CommunityToolkit.Graph.Uwp` package.
 
@@ -21,8 +18,10 @@ The [PeoplePicker](/dotnet/api/microsoft.toolkit.graph.controls.peoplepicker) se
 
 ## Syntax
 
-```xaml
-  <wgt:PeoplePicker/>
+```xml
+<Grid xmlns:controls="using:CommunityToolkit.Graph.Uwp.Controls">
+    <controls:PeoplePicker/>
+</Grid>
 ```
 
 ## Sample Output
@@ -33,23 +32,19 @@ The [PeoplePicker](/dotnet/api/microsoft.toolkit.graph.controls.peoplepicker) se
 
 | Property | Type | Description |
 | -- | -- | -- |
-| PickedPeople | ObservableCollection\<Person> | Gets the set of Person objects chosen by the user. |
-| SuggestedPeople | ObservableCollection\<Person> | Gets or sets collection of people suggested by the graph from the user's query. |
-
-## Sample Project
-
-[PeoplePicker sample page Source](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/rel/7.0.0/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PeoplePicker). You can [see this in action](uwpct://Controls?sample=PeoplePicker) in [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
+| PickedPeople | ObservableCollection&lt;Person&gt; | Gets the set of Person objects chosen by the user. |
+| SuggestedPeople | ObservableCollection&lt;Person&gt; | Gets or sets collection of people suggested by the graph from the user's query. |
 
 ## Requirements
 
 | Device family | Universal, MinVersion or higher |
 | -- | -- |
-| Namespace | Microsoft.Toolkit.Graph.Controls |
-| NuGet package | [Microsoft.Toolkit.Graph.Controls](https://www.nuget.org/packages/Microsoft.Toolkit.Graph.Controls) |
+| Namespace | CommunityToolkit.Graph.Uwp.Controls |
+| NuGet package | [CommunityToolkit.Graph.Uwp](https://www.nuget.org/packages/CommunityToolkit.Graph.Uwp) |
 
 ## API
 
-* [PeoplePicker source code](https://github.com/windows-toolkit/Graph-Controls/tree/rel/7.0.0/Microsoft.Toolkit.Graph.Controls/Controls/PeoplePicker)
+* [PeoplePicker source code](https://github.com/windows-toolkit/Graph-Controls/tree/dev/7.1.0/CommunityToolkit.Graph.Uwp/Controls/PeoplePicker)
 
 ## Related Topics
 

--- a/docs/graph/controls/PersonView.md
+++ b/docs/graph/controls/PersonView.md
@@ -9,10 +9,7 @@ dev_langs:
 
 # (Preview) PersonView XAML Control
 
-The [PersonView](/dotnet/api/microsoft.toolkit.graph.controls.personview) is used to display a person or contact by using their photo, name, and/or email address.
-
-> [!div class="nextstepaction"]
-> [Try it in the sample app](uwpct://controls?sample=PersonView)
+The PersonView control is used to display a person or contact by using their photo, name, and/or email address.
 
 > Available in the `CommunityToolkit.Graph.Uwp` package.
 
@@ -21,8 +18,10 @@ The [PersonView](/dotnet/api/microsoft.toolkit.graph.controls.personview) is use
 
 ## Syntax
 
-```xaml
-  <wgt:PersonView PersonQuery="me" ShowEmail="True"/>
+```xml
+<Grid xmlns:controls="using:CommunityToolkit.Graph.Uwp.Controls">
+    <controls:PersonView PersonQuery="me" PersonViewType="TwoLines" />
+</Grid>
 ```
 
 ## Sample Output
@@ -37,25 +36,20 @@ The [PersonView](/dotnet/api/microsoft.toolkit.graph.controls.personview) is use
 | IsLargeImage | bool | Value indicating if the image/circle size should be larger. |
 | PersonDetails | Person | Details about this person retrieved from the graph or provided by the developer. |
 | PersonQuery | string | Automatically retrieve data on the specified query from the graph.  Use 'me' to retrieve info about the current user.  Otherwise, it's best to use an e-mail address as a query. |
-| ShowEmail | bool | Value indicating whether the user's email address should be displayed. |
-| ShowName | bool | Value indicating whether the user's name should be displayed. |
+| PersonViewType | PersonViewType | Value indicating what type of details should be displayed. |
 | UserId | string | Gets or sets the UserId of the displayed person. |
 | UserPhoto | BitmapImage | Gets or sets the displayed photo. |
-
-## Sample Project
-
-[PersonView sample page Source](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/rel/7.0.0/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PersonView). You can [see this in action](uwpct://Controls?sample=PersonView) in [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 
 | Device family | Universal, MinVersion or higher |
 | -- | -- |
-| Namespace | Microsoft.Toolkit.Graph.Controls |
-| NuGet package | [Microsoft.Toolkit.Graph.Controls](https://www.nuget.org/packages/Microsoft.Toolkit.Graph.Controls) |
+| Namespace | CommunityToolkit.Graph.Uwp.Controls |
+| NuGet package | [CommunityToolkit.Graph.Uwp](https://www.nuget.org/packages/CommunityToolkit.Graph.Uwp) |
 
 ## API
 
-* [PersonView source code](https://github.com/windows-toolkit/Graph-Controls/tree/rel/7.0.0/Microsoft.Toolkit.Graph.Controls/Controls/PersonView)
+* [PersonView source code](https://github.com/windows-toolkit/Graph-Controls/tree/dev/7.1.0/CommunityToolkit.Graph.Uwp/Controls/PersonView)
 
 ## Related Topics
 

--- a/docs/graph/controls/PersonView.md
+++ b/docs/graph/controls/PersonView.md
@@ -20,7 +20,7 @@ The PersonView control is used to display a person or contact by using their pho
 
 ```xml
 <Grid xmlns:controls="using:CommunityToolkit.Graph.Uwp.Controls">
-    <controls:PersonView PersonQuery="me" PersonViewType="TwoLines" />
+    <controls:PersonView PersonQuery="me" PersonViewType="OneLine" />
 </Grid>
 ```
 
@@ -36,7 +36,7 @@ The PersonView control is used to display a person or contact by using their pho
 | IsLargeImage | bool | Value indicating if the image/circle size should be larger. |
 | PersonDetails | Person | Details about this person retrieved from the graph or provided by the developer. |
 | PersonQuery | string | Automatically retrieve data on the specified query from the graph.  Use 'me' to retrieve info about the current user.  Otherwise, it's best to use an e-mail address as a query. |
-| PersonViewType | PersonViewType | Value indicating what type of details should be displayed. |
+| PersonViewType | PersonViewType | Value indicating what type of details should be displayed: `Avatar`, `OneLine`, `TwoLine` |
 | UserId | string | Gets or sets the UserId of the displayed person. |
 | UserPhoto | BitmapImage | Gets or sets the displayed photo. |
 

--- a/docs/graph/getting-started.md
+++ b/docs/graph/getting-started.md
@@ -73,7 +73,7 @@ You can also use the [LoginButton](./controls/LoginButton.md) control in UWP XAM
 
 ## 3. Make a Graph call
 
-Once you are authenticated, you can then make requests to the Graph using the GraphServiceClient instance via [ProviderExtensions](./helpers/ProviderExtensions.md).
+Once you are authenticated, you can then make requests to the Graph using the GraphServiceClient instance via [extensions](./helpers/extensions.md).
 
 > Install the `CommunityToolkit.Graph` package.
 

--- a/docs/graph/getting-started.md
+++ b/docs/graph/getting-started.md
@@ -14,7 +14,9 @@ To get started using Graph data in your application, you'll first need to enable
 > [!IMPORTANT]
 > These packages are in preview. To get started using WCT preview packages visit the [WCT Preview Packages wiki page](https://aka.ms/wct/wiki/previewpackages).
 
-## 1A. Setup authentication with MSAL
+## Set the global authentication provider
+
+### Authenticate with MSAL
 
 Leverage the official Microsoft Authentication Library (MSAL) to enable authentication in NetStandard 2.0 applications using [MsalProvider](./authentication/msal.md).
 
@@ -37,7 +39,7 @@ Leverage the official Microsoft Authentication Library (MSAL) to enable authenti
 
 > Note: You can use the `Scopes` property to preemptively request permissions from the user of your app for data your app needs to access from Microsoft Graph.
 
-## 1B. Setup authentication with WindowsProvider
+### Authenticate with WindowsProvider
 
 Try out the [WindowsProvider](./authentication/windows.md) to enable authentication based on the native Windows Account Manager (WAM) APIs in your UWP apps, without requiring a dependency on MSAL.
 
@@ -53,7 +55,7 @@ Try out the [WindowsProvider](./authentication/windows.md) to enable authenticat
     ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes);
     ```
 
-## 2. Sign in a user
+## Sign in a user
 
 Call `SignInAsync` to initiate the login process. This will prompt the user to specify an account or provide credentials.
 
@@ -71,7 +73,7 @@ You can also use the [LoginButton](./controls/LoginButton.md) control in UWP XAM
 </Grid>
 ```
 
-## 3. Make a Graph call
+## Make a Graph call
 
 Once you are authenticated, you can then make requests to the Graph using the GraphServiceClient instance via [extensions](./helpers/extensions.md).
 

--- a/docs/graph/getting-started.md
+++ b/docs/graph/getting-started.md
@@ -1,0 +1,131 @@
+---
+title: Getting started with WCT Graph Helpers and Controls
+author: shweaver-MSFT
+description: Get started using authentication providers and Graph powered helpers from the Windows Community Toolkit.
+keywords: uwp, wpf, netstandard, windows, community, toolkit, graph, login, authentication, provider, providers, identity
+dev_langs:
+  - csharp
+---
+
+# Getting Started
+
+To get started using Graph data in your application, you'll first need to enable authentication.
+
+> [!IMPORTANT]
+> These packages are in preview. To get started using WCT preview packages visit the [WCT Preview Packages wiki page](https://aka.ms/wct/wiki/previewpackages).
+
+## 1A. Setup authentication with MSAL
+
+Leverage the official Microsoft Authentication Library (MSAL) to enable authentication in NetStandard 2.0 applications using [MsalProvider](./authentication/MsalProvider.md). 
+
+1. Register your app in Azure AAD
+
+    Before requesting data from [Microsoft Graph](https://graph.microsoft.com), you will need to [register your application](/azure/active-directory/develop/quickstart-register-app) to get a **ClientID**.
+
+    > After finishing the initial registration page, you will also need to add an additional redirect URI. Click on "Add a Redirect URI", then "Add a platform", and then on "Mobile and desktop applications". Check the `https://login.microsoftonline.com/common/oauth2/nativeclient` checkbox on that page. Then click "Configure".
+1. Install the `CommunityToolkit.Authentication.Msal` package.
+1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [MsalProvider](./authentication/MsalProvider.md) with clientId and pre-configured scopes:
+
+    ```csharp
+    using CommunityToolkit.Authentication;
+
+    string clientId = "YOUR-CLIENT-ID-HERE";
+    string[] scopes = new string[] { "User.Read" };
+
+    ProviderManager.Instance.GlobalProvider = new MsalProvider(clientId, scopes);
+    ```
+
+> Note: You can use the `Scopes` property to preemptively request permissions from the user of your app for data your app needs to access from Microsoft Graph.
+
+## 1B. Setup authentication with WindowsProvider
+
+Try out the [WindowsProvider](./authentication/WindowsProvider.md) to enable authentication based on the native Windows Account Manager (WAM) APIs in your UWP apps, without requiring a dependency on MSAL.
+
+1. Associate your app with the Microsoft Store. The app association will act as our minimal app registration for authenticating consumer MSAs. See the [WindowsProvider docs](https://github.com/windows-toolkit/Graph-Controls/edit/main/Docs/WindowsProvider.md) for more details.
+1. Install the `CommunityToolkit.Authentication.Uwp` package
+1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [WindowsProvider](./authentication/WindowsProvider.md) with pre-configured scopes:
+
+    ```csharp
+    using CommunityToolkit.Authentication;
+
+    string[] scopes = new string[] { "User.Read" };
+
+    ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes);
+    ```
+
+## 2. Sign in a user
+
+Call the `SignInAsync` method to initiate the login process. This will prompt the user to specify an account or provide credentials.
+
+  ```csharp
+using CommunityToolkit.Authentication;
+
+await ProviderManager.Instance.GlobalProvider.SignInAsync();
+```
+
+You can also use the [LoginButton](./controls/LoginButton.md) control in UWP XAML apps to support the full sign in/out lifecycle and even display the user's photo and name when signed in.
+
+```xml
+<Grid xmlns:controls="using:CommunityToolkit.Graph.Uwp.Controls">
+    <controls:LoginButton>
+</Grid>
+
+```
+
+## 3. Make a Graph call
+
+Once you are authenticated, you can then make requests to the Graph using the GraphServiceClient instance via [ProviderExtensions](./helpers/ProviderExtensions.md).
+
+> Install the `CommunityToolkit.Graph` package.
+
+```csharp
+using CommunityToolkit.Authentication;
+using CommunityToolkit.Graph.Extensions;
+
+ProviderManager.Instance.ProviderUpdated += (s, e)
+{
+    IProvider provider = ProviderManager.Instance.GlobalProvider;
+    if (e.Reason == ProviderManagerChangedState.ProviderStateChanged &&
+        provider?.State == ProviderState.SignedIn)
+    {
+        var graphClient = provider.GetClient();
+        var me = await graphClient.Me.Request().GetAsync();
+    }
+}
+```
+
+### Use the Beta API
+
+You can use the `ProviderManager.Instance` to listen to changes in authentication status with the `ProviderUpdated` event or get direct access to the [.NET Graph Beta API](https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet) through `ProviderManager.Instance.GlobalProvider.GetBetaClient()`, just be sure to check if the `GlobalProvider` has been set first and its `State` is `SignedIn`:
+
+```csharp
+using CommunityToolkit.Authentication;
+using CommunityToolkit.Graph.Extensions;
+
+public ImageSource GetMyPhoto()
+{
+    IProvider provider = ProviderManager.Instance.GlobalProvider;
+
+    if (provider?.State == ProviderState.SignedIn)
+    {
+        // Get the beta client
+        GraphServiceClient betaGraphClient = provider.GetBetaClient();
+
+        try
+        {
+            // Make a request to the beta endpoint for the current user's photo.
+            var photoStream = await betaGraphClient.Me.Photo.Content.Request().GetAsync();
+
+            using var ras = photoStream.AsRandomAccessStream();
+            var bitmap = new BitmapImage();
+            await bitmap.SetSourceAsync(ras);
+
+            return bitmap;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+```

--- a/docs/graph/getting-started.md
+++ b/docs/graph/getting-started.md
@@ -16,7 +16,7 @@ To get started using Graph data in your application, you'll first need to enable
 
 ## 1A. Setup authentication with MSAL
 
-Leverage the official Microsoft Authentication Library (MSAL) to enable authentication in NetStandard 2.0 applications using [MsalProvider](./authentication/MsalProvider.md). 
+Leverage the official Microsoft Authentication Library (MSAL) to enable authentication in NetStandard 2.0 applications using [MsalProvider](./authentication/msal.md). 
 
 1. Register your app in Azure AAD
 
@@ -24,7 +24,7 @@ Leverage the official Microsoft Authentication Library (MSAL) to enable authenti
 
     > After finishing the initial registration page, you will also need to add an additional redirect URI. Click on "Add a Redirect URI", then "Add a platform", and then on "Mobile and desktop applications". Check the `https://login.microsoftonline.com/common/oauth2/nativeclient` checkbox on that page. Then click "Configure".
 1. Install the `CommunityToolkit.Authentication.Msal` package.
-1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [MsalProvider](./authentication/MsalProvider.md) with clientId and pre-configured scopes:
+1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [MsalProvider](./authentication/msal.md) with clientId and pre-configured scopes:
 
     ```csharp
     using CommunityToolkit.Authentication;
@@ -39,11 +39,11 @@ Leverage the official Microsoft Authentication Library (MSAL) to enable authenti
 
 ## 1B. Setup authentication with WindowsProvider
 
-Try out the [WindowsProvider](./authentication/WindowsProvider.md) to enable authentication based on the native Windows Account Manager (WAM) APIs in your UWP apps, without requiring a dependency on MSAL.
+Try out the [WindowsProvider](./authentication/windows.md) to enable authentication based on the native Windows Account Manager (WAM) APIs in your UWP apps, without requiring a dependency on MSAL.
 
-1. Associate your app with the Microsoft Store. The app association will act as our minimal app registration for authenticating consumer MSAs. See the [WindowsProvider docs](https://github.com/windows-toolkit/Graph-Controls/edit/main/Docs/WindowsProvider.md) for more details.
+1. Associate your app with the Microsoft Store. The app association will act as our minimal app registration for authenticating consumer MSAs. See [WindowsProvider](./authentication/windows.md) for more details.
 1. Install the `CommunityToolkit.Authentication.Uwp` package
-1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [WindowsProvider](./authentication/WindowsProvider.md) with pre-configured scopes:
+1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [WindowsProvider](./authentication/windows.md) with pre-configured scopes:
 
     ```csharp
     using CommunityToolkit.Authentication;
@@ -55,7 +55,7 @@ Try out the [WindowsProvider](./authentication/WindowsProvider.md) to enable aut
 
 ## 2. Sign in a user
 
-Call the `SignInAsync` method to initiate the login process. This will prompt the user to specify an account or provide credentials.
+Call `SignInAsync` to initiate the login process. This will prompt the user to specify an account or provide credentials.
 
   ```csharp
 using CommunityToolkit.Authentication;
@@ -67,9 +67,8 @@ You can also use the [LoginButton](./controls/LoginButton.md) control in UWP XAM
 
 ```xml
 <Grid xmlns:controls="using:CommunityToolkit.Graph.Uwp.Controls">
-    <controls:LoginButton>
+    <controls:LoginButton />
 </Grid>
-
 ```
 
 ## 3. Make a Graph call

--- a/docs/graph/getting-started.md
+++ b/docs/graph/getting-started.md
@@ -83,11 +83,10 @@ Once you are authenticated, you can then make requests to the Graph using the Gr
 using CommunityToolkit.Authentication;
 using CommunityToolkit.Graph.Extensions;
 
-ProviderManager.Instance.ProviderUpdated += (s, e)
+ProviderManager.Instance.ProviderStateChanged += (s, e)
 {
     IProvider provider = ProviderManager.Instance.GlobalProvider;
-    if (e.Reason == ProviderManagerChangedState.ProviderStateChanged &&
-        provider?.State == ProviderState.SignedIn)
+    if (provider?.State == ProviderState.SignedIn)
     {
         var graphClient = provider.GetClient();
         var me = await graphClient.Me.Request().GetAsync();

--- a/docs/graph/getting-started.md
+++ b/docs/graph/getting-started.md
@@ -16,7 +16,7 @@ To get started using Graph data in your application, you'll first need to enable
 
 ## 1A. Setup authentication with MSAL
 
-Leverage the official Microsoft Authentication Library (MSAL) to enable authentication in NetStandard 2.0 applications using [MsalProvider](./authentication/msal.md). 
+Leverage the official Microsoft Authentication Library (MSAL) to enable authentication in NetStandard 2.0 applications using [MsalProvider](./authentication/msal.md).
 
 1. Register your app in Azure AAD
 

--- a/docs/graph/helpers/ProviderExtensions.md
+++ b/docs/graph/helpers/ProviderExtensions.md
@@ -18,7 +18,7 @@ The `ProviderExtensions` static class is available in the `CommunityToolkit.Grap
 
 ## Call Microsoft Graph APIs
 
-Once authenticated, you can make API calls to Microsoft Graph using a preconfigured GraphServiceClient instance. Access to the client is enabled through an extension method on [IProvider](../authentication/IProvider.md) called, `GetClient()`.
+Once authenticated, you can make API calls to Microsoft Graph using a preconfigured GraphServiceClient instance. Access to the client is enabled through an extension method on [IProvider](../authentication/custom.md) called, `GetClient()`.
 
 ```csharp
 using CommunityToolkit.Authentication;

--- a/docs/graph/helpers/extensions.md
+++ b/docs/graph/helpers/extensions.md
@@ -1,24 +1,22 @@
 ---
-title: ProviderExtensions
+title: Microsoft Graph Extensions
 author: shweaver-MSFT
-description: Extension methods on IProvider that enable access to the pre-configured GraphServiceClient instance.
+description: Extension methods that enable Graph API calls using the global authentication provider.
 keywords: uwp, wpf, netstandard, windows, community, toolkit, graph, provider, providers, extensions
 dev_langs:
   - csharp
 ---
 
-# ProviderExtensions
+# Microsoft Graph Extensions
 
-The `ProviderExtensions` static class is available in the `CommunityToolkit.Graph` package. These extensions help you make calls to various Graph APIs.
-
-> Available in the `CommunityToolkit.Graph` package.
+Use toolkit extensions to help you make calls to Graph APIs using the global authentication provider. Available in the `CommunityToolkit.Graph` package, `CommunityToolkit.Graph.Extensions` namespace.
 
 > [!IMPORTANT]
 > Windows Community Toolkit - Graph Controls and Helpers packages are in preview. To get started using WCT preview packages visit the [WCT Preview Packages wiki page](https://aka.ms/wct/wiki/previewpackages).
 
 ## Call Microsoft Graph APIs
 
-Once authenticated, you can make API calls to Microsoft Graph using a preconfigured GraphServiceClient instance. Access to the client is enabled through an extension method on [IProvider](../authentication/custom.md) called, `GetClient()`.
+Once authenticated, you can make API calls to Microsoft Graph using a preconfigured `GraphServiceClient` instance. Access to the client is enabled through an extension method on [IProvider](../authentication/custom.md) called, `GetClient()`.
 
 ```csharp
 using CommunityToolkit.Authentication;
@@ -73,7 +71,9 @@ public ImageSource GetMyPhoto()
 }
 ```
 
-## Methods
+## Extension methods
+
+The following extension methods are available on `IProvider` via the `CommunityToolkit.Graph.Extensions` namespace.
 
 | Method | Arguments | Returns | Description |
 | -- | -- | -- | -- |

--- a/docs/graph/overview.md
+++ b/docs/graph/overview.md
@@ -42,14 +42,14 @@ Check out the [Getting Started](./getting-started.md) guide for details on how t
 
 ## Learn More
 
-**Authentication Providers**
+### Authentication Providers
 
 Hook into a lightweight framework for authenticating users and responding to login state changes: [Authentication Providers Overview](./authentication/overview.md)
 
-**Graph Helpers**
+### Graph Helpers
 
 See [Microsoft Graph Extensions](./helpers/extensions.md) to learn how to get access to a preconfigured GraphServiceClient and make adhoc API calls using the Graph SDK.
 
-**Graph Controls**
+### Graph Controls
 
 Build Graph experiences with XAML controls and helpers made for UWP, such as [LoginButton](./controls/LoginButton.md) or [PersonView](./controls/PersonView.md).

--- a/docs/graph/overview.md
+++ b/docs/graph/overview.md
@@ -36,103 +36,20 @@ For more info on our roadmap, check out the current [Release Plan](https://githu
 | `CommunityTookit.Graph` | NetStandard 2.0 |
 | `CommunityToolkit.Graph.Uwp` | UWP Windows 10 17763 |
 
-## <a name="documentation"></a> Getting Started
+## Getting Started
 
-To get started using Graph data in your application, you'll first need to enable authentication.
+Check out the [Getting Started](./getting-started.md) guide for details on how to get authenticated and start calling Graph APIs.
 
-> [!IMPORTANT]
-> These packages are in preview. To get started using WCT preview packages visit the [WCT Preview Packages wiki page](https://aka.ms/wct/wiki/previewpackages).
+## Learn More
 
-### 1A. Setup authentication with MSAL
+**Authentication Providers**
 
-Leverage the official Microsoft Authentication Library (MSAL) to enable authentication in any NetStandard application.
+Hook into a lightweight framework for authenticating users and responding to login state changes: [Authentication Providers Overview](./authentication/overview.md)
 
-1. Register your app in Azure AAD
+**Graph Helpers**
 
-    Before requesting data from [Microsoft Graph](https://graph.microsoft.com), you will need to [register your application](/azure/active-directory/develop/quickstart-register-app) to get a **ClientID**.
+See [ProviderExtensions](./helpers/ProviderExtensions.md) to learn how to get access to a preconfigured GraphServiceClient and make adhoc API calls using the Graph SDK.
 
-    > After finishing the initial registration page, you will also need to add an additional redirect URI. Click on "Add a Redirect URI", then "Add a platform", and then on "Mobile and desktop applications". Check the `https://login.microsoftonline.com/common/oauth2/nativeclient` checkbox on that page. Then click "Configure".
-1. Install the `CommunityToolkit.Authentication.Msal` package.
-1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [MsalProvider](./authentication/MsalProvider.md) with clientId and pre-configured scopes:
+**Graph Controls**
 
-    ```csharp
-    using CommunityToolkit.Authentication;
-
-    string clientId = "YOUR-CLIENT-ID-HERE";
-    string[] scopes = new string[] { "User.Read" };
-
-    ProviderManager.Instance.GlobalProvider = new MsalProvider(clientId, scopes);
-    ```
-
-> Note: You can use the `Scopes` property to preemptively request permissions from the user of your app for data your app needs to access from Microsoft Graph.
-
-### 1B. Setup authentication with WindowsProvider
-
-Try out the [WindowsProvider](./authentication/WindowsProvider.md) to enable authentication based on the native Windows Account Manager (WAM) APIs in your UWP apps, without requiring a dependency on MSAL.
-
-1. Associate your app with the Microsoft Store. The app association will act as our minimal app registration for authenticating consumer MSAs. See the [WindowsProvider docs](https://github.com/windows-toolkit/Graph-Controls/edit/main/Docs/WindowsProvider.md) for more details.
-1. Install the `CommunityToolkit.Authentication.Uwp` package
-1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [WindowsProvider](./authentication/WindowsProvider.md) with pre-configured scopes:
-
-    ```csharp
-    using CommunityToolkit.Authentication;
-
-    string[] scopes = new string[] { "User.Read" };
-
-    ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes);
-    ```
-
-### 2. Make a Graph call
-
-Once you are authenticated, you can then make requests to the Graph using the GraphServiceClient instance via [ProviderExtensions](./helpers/ProviderExtensions.md).
-
-> Install the `CommunityToolkit.Graph` package.
-
-```
-using CommunityToolkit.Authentication;
-using CommunityToolkit.Graph.Extensions;
-
-var provider = ProviderManager.Instance.GlobalProvider;
-
-if (provider != null && provider.State == ProviderState.SignedIn)
-{
-    var graphClient = provider.GetClient();
-    var me = await graphClient.Me.Request().GetAsync();
-}
-```
-
-**That's all you need to get started!**
-
-You can use the `ProviderManager.Instance` to listen to changes in authentication status with the `ProviderUpdated` event or get direct access to the [.NET Graph Beta API](https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet) through `ProviderManager.Instance.GlobalProvider.GetBetaClient()`, just be sure to check if the `GlobalProvider` has been set first and its `State` is `SignedIn`:
-
-```csharp
-using CommunityToolkit.Authentication;
-using CommunityToolkit.Graph.Extensions;
-
-public ImageSource GetMyPhoto()
-{
-    IProvider provider = ProviderManager.Instance.GlobalProvider;
-
-    if (provider?.State == ProviderState.SignedIn)
-    {
-        // Get the beta client
-        GraphServiceClient betaGraphClient = provider.GetBetaClient();
-
-        try
-        {
-            // Make a request to the beta endpoint for the current user's photo.
-            var photoStream = await betaGraphClient.Me.Photo.Content.Request().GetAsync();
-
-            using var ras = photoStream.AsRandomAccessStream();
-            var bitmap = new BitmapImage();
-            await bitmap.SetSourceAsync(ras);
-
-            return bitmap;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-}
-```
+Build Graph experiences with XAML controls and helpers made for UWP, such as [LoginButton](./controls/LoginButton.md) or [PersonView](./controls/PersonView.md).

--- a/docs/graph/overview.md
+++ b/docs/graph/overview.md
@@ -48,7 +48,7 @@ Hook into a lightweight framework for authenticating users and responding to log
 
 **Graph Helpers**
 
-See [Microsoft Graph Extensions](./helpers/wextensions.md) to learn how to get access to a preconfigured GraphServiceClient and make adhoc API calls using the Graph SDK.
+See [Microsoft Graph Extensions](./helpers/extensions.md) to learn how to get access to a preconfigured GraphServiceClient and make adhoc API calls using the Graph SDK.
 
 **Graph Controls**
 

--- a/docs/graph/overview.md
+++ b/docs/graph/overview.md
@@ -48,7 +48,7 @@ Hook into a lightweight framework for authenticating users and responding to log
 
 **Graph Helpers**
 
-See [ProviderExtensions](./helpers/ProviderExtensions.md) to learn how to get access to a preconfigured GraphServiceClient and make adhoc API calls using the Graph SDK.
+See [Microsoft Graph Extensions](./helpers/wextensions.md) to learn how to get access to a preconfigured GraphServiceClient and make adhoc API calls using the Graph SDK.
 
 **Graph Controls**
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -83,13 +83,13 @@
 
 ### [Authentication Overview](graph/authentication/overview.md)
 
-### [IProvider](graph/authentication/IProvider.md)
-
 ### [ProviderManager](graph/authentication/ProviderManager.md)
 
-### [MsalProvider](graph/authentication/MsalProvider.md)
+### [MSAL provider](graph/authentication/msal.md)
 
-### [WindowsProvider](graph/authentication/WindowsProvider.md)
+### [Windows provider](graph/authentication/windows.md)
+
+### [Custom provider](graph/authentication/custom.md)
 
 ## Helpers
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -77,6 +77,8 @@
 
 ## [Overview](graph/overview.md)
 
+## [Getting Started](graph/getting-started.md)
+
 ## Authentication
 
 ### [Authentication Overview](graph/authentication/overview.md)
@@ -93,17 +95,17 @@
 
 ### [ProviderExtensions](graph/helpers/ProviderExtensions.md)
 
-<!-- ### RoamingSettingsHelper (Coming soon!)
+<!-- ### RoamingSettingsHelper -->
 
 ## Controls
 
-### GraphPresenter (Coming soon!)
+<!-- ### GraphPresenter -->
 
 ### [LoginButton (Preview)](graph/controls/LoginButton.md)
 
 ### [PersonView (Preview)](graph/controls/PersonView.md)
 
-### [PeoplePicker (Preview)](graph/controls/PeoplePicker.md) -->
+### [PeoplePicker (Preview)](graph/controls/PeoplePicker.md)
 
 # WinUI 3
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -93,7 +93,7 @@
 
 ## Helpers
 
-### [ProviderExtensions](graph/helpers/ProviderExtensions.md)
+### [Microsoft Graph Extensions](graph/helpers/extensions.md)
 
 <!-- ### RoamingSettingsHelper -->
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -491,9 +491,9 @@
 
 ### [SharePointFileList](archive/graph/SharePointFileList.md)
 
-### [InteractiveProviderBehavior](graph/providers/InteractiveProviderBehavior.md)
+### [InteractiveProviderBehavior](archive/graph/providers/InteractiveProviderBehavior.md)
 
-### [MockProviderBehavior](graph/providers/MockProviderBehavior.md)
+### [MockProviderBehavior](archive/graph/providers/MockProviderBehavior.md)
 
 ## Parsers
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -93,7 +93,7 @@
 
 ### [ProviderExtensions](graph/helpers/ProviderExtensions.md)
 
-### RoamingSettingsHelper (Coming soon!)
+<!-- ### RoamingSettingsHelper (Coming soon!)
 
 ## Controls
 
@@ -103,7 +103,7 @@
 
 ### [PersonView (Preview)](graph/controls/PersonView.md)
 
-### [PeoplePicker (Preview)](graph/controls/PeoplePicker.md)
+### [PeoplePicker (Preview)](graph/controls/PeoplePicker.md) -->
 
 # WinUI 3
 


### PR DESCRIPTION
## What changes to the docs does this PR provide?

I've made a variety of changes based on the feedback received during our internal bug bash. 

- Added getting started page with increased clarity.
- Added "manual" Graph call example to authentication overview
- Added example of retrieving access tokens
- Migrated helpful content from ProviderManager into the auth overview
- Various typo fixes and structure adjustments
- Documented provider constructors
- Updated controls docs
- Added redirect configuration for newly archived files:
  - InteractiveProviderBehavior
  - MockProviderBehavior

You can see the redirect by visiting this link:
https://review.docs.microsoft.com/en-us/windows/communitytoolkit/graph/providers/interactiveproviderbehavior?branch=pr-en-us-533

The files no longer exist in the /graph/providers path, yet the correct page should be accessible.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Correctly picked the right branch to base the change off (`dev` for new features, `master` for typos/improvements)
- [ ] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/rel/7.0.0/docs/.template.md)
- [ ] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/rel/7.0.0/docs/toc.md)
- [ ] Ran against a spell and grammar checker 
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
