### PR TITLE
Fix a mistake in the "Register a message in some module" comment

### DIFF
--- a/docs/mvvm/Messenger.md
+++ b/docs/mvvm/Messenger.md
@@ -41,7 +41,7 @@ public class LoggedInUserChangedMessage : ValueChangedMessage<User>
 WeakReferenceMessenger.Default.Register<LoggedInUserChangedMessage>(this, (r, m) =>
 {
     // Handle the message here, with r being the recipient and m being the
-    // input messenger. Using the recipient passed as input makes it so that
+    // input message. Using the recipient passed as input makes it so that
     // the lambda expression doesn't capture "this", improving performance.
 });
 


### PR DESCRIPTION
<!-- When opening a PR, start by forking this repository. Then, based on the type of change you're making you'll need to create a new branch from either the `master` or `dev` branches:

If you have a typo or existing document improvement to an already shipped feature, please base your change off of the [master branch](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/tree/master). This will allow us to get the change to the published documentation between releases.

For documentation regarding any new features, please base your fork off the last updated dev branch. For example: 'dev/7.1.0'.

We will merge updates from the current main branch to the latest dev branch to keep it in-sync with any updated changes. We will periodically sync the main branch automatically with the live branch to pick up any changes made over time. When we make a new release, we will integrate the dev branch into the main branch in order to publish documentation for new features.

Documentation Links
**This link is currently only available for Microsoft Employees** - [Staging review from 'master' branch](https://review.docs.microsoft.com/windows/communitytoolkit/?branch=master)
- [Live site from 'live' branch](/windows/communitytoolkit) -->

## What changes to the docs does this PR provide?
<!-- Please describe the updated information in detail -->
This PR fixes a small mistake/typo in the "Register a message in some module" code example - there is a comment describing the second lambda argument (m) as "input messenger" but it should be "input message".

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Correctly picked the right branch to base the change off (`dev` for new features, `master` for typos/improvements)
- [ ] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/rel/7.0.0/docs/.template.md)
- [ ] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/rel/7.0.0/docs/toc.md)
- [x] Ran against a spell and grammar checker 
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
