### PR TITLE
Fix invalid value for VisualExtensions.NormalizedCenterPoint code example

### DIFF
--- a/docs/extensions/VisualExtensions.md
+++ b/docs/extensions/VisualExtensions.md
@@ -27,7 +27,7 @@ Here is an example of how the `VisualExtensions` type can be used to directly se
     ui:VisualExtensions.Opacity="0.5"
     ui:VisualExtensions.RotationAngleInDegrees="80"
     ui:VisualExtensions.Scale="2, 0.5, 1"
-    ui:VisualExtensions.NormalizedCenterPoint="0.5, 0.5, 0" />
+    ui:VisualExtensions.NormalizedCenterPoint="0.5, 0.5" />
 ```
 
 > [!NOTE]


### PR DESCRIPTION
After upgrading to version 7.0.2 of the toolkit I noticed that NormalizedCenterPoint is now a Vector2 instead of Vector3, trying to set a Z-coordinate like in this example causes the exception `Failed to assign to property 'Microsoft.Toolkit.Uwp.UI.VisualExtensions.NormalizedCenterPoint'.`.

The[ intellisense documentation](https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/e4e06cbea6790b744b01a1e9630cd9a710814654/Microsoft.Toolkit.Uwp.UI/Extensions/VisualExtensions.cs#L344) also states that it's supposed to be a Vector2.