### PR TITLE
Made list of controls in supported feature more specific

### DIFF
--- a/docs/gaze/GazeInteractionLibrary.md
+++ b/docs/gaze/GazeInteractionLibrary.md
@@ -33,7 +33,7 @@ To use the gaze input APIs, you must register the gazeInput capability in the ap
 
 The Gaze Interaction Library currently supports the following features:
 
-* Dwell based activation of XAML controls, like buttons, toggle buttons, check boxes, etc.
+* Dwell based activation of XAML button and toggle button controls
 * Enabling gaze interactions for the entire XAML page or for a portion of it (like a single control)
 * Customizing the dwell times associated with specific controls
 * Controlling repetition of the dwell invocation of controls


### PR DESCRIPTION
The previous description of supported controls stated "Dwell based activation of XAML controls, like buttons, toggle buttons, check boxes, etc.". While the toolkit may support things other than buttons and toggle buttons, such support is limited or untested. Rich controls like TextBox are definitely out-of-scope of the current implementation.

Simplified bullet point to simply promise button and toggle button support.

Fixes https://github.com/CommunityToolkit/WindowsCommunityToolkit/issues/3100

