### PR TITLE
Fix ParallelHelper sample

### DIFF
--- a/docs/high-performance/ParallelHelper.md
+++ b/docs/high-performance/ParallelHelper.md
@@ -72,7 +72,7 @@ Here is another example, this time using the `For` API to initialize all the ite
 ```csharp
 public readonly struct ArrayInitializer : IAction
 {
-    private int[] array;
+    private readonly int[] array;
 
     public ArrayInitializer(int[] array)
     {


### PR DESCRIPTION
## What changes to the docs does this PR provide?

Add readonly modifier to private field for the `ArrayInitializer` sample. Will not compile without it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [✓ ] Correctly picked the right branch to base the change off (`dev` for new features, `master` for typos/improvements)
- [N/A ] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/.template.md)
- [N/A ] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/toc.md)
- [N/A ] Ran against a spell and grammar checker 
- [ ✓] Contains **NO** breaking changes