### PR TITLE
login button requires scope (User.Read)

### DIFF
--- a/docs/graph/controls/LoginButton.md
+++ b/docs/graph/controls/LoginButton.md
@@ -49,6 +49,7 @@ Available in the `CommunityToolkit.Graph.Uwp` package.
 
 * **Namespace:** CommunityToolkit.Graph.Uwp.Controls
 * **NuGet package:** [CommunityToolkit.Graph.Uwp](https://www.nuget.org/packages/CommunityToolkit.Graph.Uwp)
+* **Scope:** `User.Read`
 
 ## API
 


### PR DESCRIPTION
## Fixes # <!-- Link to a relevant issue # in this docs repository (if any, otherwise remove this line) -->
The Login button requires `User.Read` scope to work. If it is not present confusing errors pop up.
## Docs for Toolkit PR [#](https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/#) <!-- Link to relevant issue or Feature PR # of the Windows Community Toolkit repo which will create a reference to the associated issue and PR once it is created, remove if not tied to an issue or feature -->

## What changes to the docs does this PR provide?
<!-- Please describe the updated information in detail -->
Adds a small line to the `LoginButton` page which clarifies which scopes are required for this control to work.
Helps clarify Windows Provider, but not MSAL like in #593

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Correctly picked the right branch to base the change off (`dev` for new features, `master` for typos/improvements)
- [x] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/.template.md)
- [x] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/toc.md)
- [x] Ran against a spell and grammar checker 
- [x] Contains **NO** breaking changes



## Other information
