### PR TITLE
Fix typos in ThrowArgumentException example

### DIFF
--- a/docs/developer-tools/ThrowHelper.md
+++ b/docs/developer-tools/ThrowHelper.md
@@ -35,11 +35,11 @@ int result = text switch
 {
     "cat" => 0,
     "dog" => 1,
-    _ => ThrowHelper.ThrowArgumentException<string>(nameof(text))
+    _ => ThrowHelper.ThrowArgumentException<int>(nameof(text))
 };
 ```
 
-Here we're using `ThrowHelper` within an expression that requires a return type of type `string`, so we can use the generic overload of `ThrowArgumentException` to make this possible. This also works with patterns such as ternary operators (`x ? a : b`), null-coalescing operators (`x = a ?? b`) null-coalescing assignment operators (`x ??= y`), and more.
+Here we're using `ThrowHelper` within an expression that requires a return type of type `int`, so we can use the generic overload of `ThrowArgumentException` to make this possible. This also works with patterns such as ternary operators (`x ? a : b`), null-coalescing operators (`x = a ?? b`) null-coalescing assignment operators (`x ??= y`), and more.
 
 ## Methods
 


### PR DESCRIPTION
## What changes to the docs does this PR provide?
The example showcasing how to use the `ThrowHelper` API contains a typo: the code expects a return type of `int` where the current example uses `ThrowArgumentException<string>`. This PR fixes that minor typo.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Correctly picked the right branch to base the change off (`dev` for new features, `master` for typos/improvements)
- [ ] ~~For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/.template.md)~~
- [ ] ~~For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/master/docs/toc.md)~~
- [x] Ran against a spell and grammar checker 
- [x] Contains **NO** breaking changes
