### PR TITLE
Update provider docs to remove "Scopes" arg from GetTokenAsync

### DIFF
--- a/docs/graph/authentication/msal.md
+++ b/docs/graph/authentication/msal.md
@@ -54,7 +54,7 @@ ProviderManager.Instance.GlobalProvider = new MsalProvider(clientId, scopes);
 
 | Method | Arguments | Returns | Description |
 | -- | -- | -- | -- |
-| GetTokenAsync | bool silentOnly = false, string[] scopes = null | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
+| GetTokenAsync | bool silentOnly = false | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
 | AuthenticateRequestAsync | HttpRequestMessage | Task | Authenticate an outgoing request. |
 | SignInAsync | | Task | Sign in a user. |
 | SignOutAsync | | Task | Sign out the current user. |

--- a/docs/graph/authentication/windows.md
+++ b/docs/graph/authentication/windows.md
@@ -128,7 +128,7 @@ ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes, accountsSe
 | Method | Arguments | Returns | Description |
 | -- | -- | -- | -- |
 | AuthenticateRequestAsync | HttpRequestMessage | Task | Authenticate an outgoing request. |
-| GetTokenAsync | bool silentOnly = true, string[] scopes = null | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
+| GetTokenAsync | bool silentOnly = true | Task&lt;string&gt; | Retrieve a token for the authenticated user. |
 | SignInAsync | | Task | Sign in a user. |
 | SignOutAsync | | Task | Sign out the current user. |
 | TrySilentSignInAsync | | Task&lt;bool&gt; | Try signing in silently, without prompts. |


### PR DESCRIPTION
<!-- When opening a PR, start by forking this repository. Then, based on the type of change you're making you'll need to create a new branch from either the `master` or `dev` branches:

If you have a typo or existing document improvement to an already shipped feature, please base your change off of the [master branch](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/tree/master). This will allow us to get the change to the published documentation between releases.

For documentation regarding any new features, please base your fork off the last updated dev branch. For example: 'dev/7.1.0'.

We will merge updates from the current main branch to the latest dev branch to keep it in-sync with any updated changes. We will periodically sync the main branch automatically with the live branch to pick up any changes made over time. When we make a new release, we will integrate the dev branch into the main branch in order to publish documentation for new features.

Documentation Links
**This link is currently only available for Microsoft Employees** - [Staging review from 'master' branch](https://review.docs.microsoft.com/windows/communitytoolkit/?branch=master)
- [Live site from 'live' branch](/windows/communitytoolkit) -->

## Fixes # <!-- Link to a relevant issue # in this docs repository (if any, otherwise remove this line) -->
## Docs for Toolkit PR [#](https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/#) <!-- Link to relevant issue or Feature PR # of the Windows Community Toolkit repo which will create a reference to the associated issue and PR once it is created, remove if not tied to an issue or feature -->

## What changes to the docs does this PR provide?
Removed scopes arg from GetTokenAsync in documentation for Windows and MSAL providers.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Correctly picked the right branch to base the change off (`dev` for new features, `master` for typos/improvements)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->

