### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/docs/animations/CompositionAnimations.md
+++ b/docs/animations/CompositionAnimations.md
@@ -170,7 +170,7 @@ Now we can add KeyFrames
 
 ## API
 
-- [Composition animations source code](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/rel/7.1.0/Microsoft.Toolkit.Uwp.UI.Animations/CompositionAnimations)
+- [Composition animations source code](https://github.com/CommunityToolkit/WindowsCommunityToolkit/tree/rel/7.1.0/Microsoft.Toolkit.Uwp.UI.Animations/Xaml)
 
 ## Related Topics
 


### PR DESCRIPTION
Fixing broken link. 

Note to author/reviewer: Composition Animations in XAML have been updated with some breaking changes. For a comprehensive list of all the available APIs, I linked the broken link to the path of the folder XAML in GitHub.
