### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/docs/animations/Fade.md
+++ b/docs/animations/Fade.md
@@ -111,7 +111,7 @@ You can change the way how the animation interpolates between keyframes by defin
 
 ## Sample Project
 
-[Fade Behavior Sample Page Source](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/rel/7.1.0/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Fade). You can [see this in action](uwpct://Animations?sample=Fade) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
+[Fade Behavior Sample Page Source](https://github.com/CommunityToolkit/WindowsCommunityToolkit/tree/rel/7.1.0/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/FadeHeader). You can [see this in action](uwpct://Animations?sample=Fade) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 
@@ -122,7 +122,7 @@ You can change the way how the animation interpolates between keyframes by defin
 
 ## API
 
-- [Fade source code](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/rel/7.1.0/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Fade.cs)
+- [Fade source code](https://github.com/CommunityToolkit/WindowsCommunityToolkit/tree/rel/7.1.0/Microsoft.Toolkit.Uwp.UI.Media/Visuals)
 
 ## Related Topics
 


### PR DESCRIPTION
Fixing broken links

Note to author/reviewer:  This behavior is no longer available in the Windows Community Toolkit. I was referring to use the effects from the Microsoft.Toolkit.Uwp.UI.Media for line 125, and for line 114 rather than removing the link I updated to the samples of FadeHeader.
