### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/docs/animations/Light.md
+++ b/docs/animations/Light.md
@@ -98,7 +98,7 @@ Await MyUIElement.Light(distance:=5, duration:=2500, delay:=250, color:=Colors.R
 
 ## Sample Project
 
-[Light Behavior Sample Page Source](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/rel/7.1.0/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Light). You can [see this in action](uwpct://Animations?sample=Light) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
+You can see this in action in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 
@@ -109,7 +109,7 @@ Await MyUIElement.Light(distance:=5, duration:=2500, delay:=250, color:=Colors.R
 
 ## API
 
-- [Light source code](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/rel/7.1.0/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Light.cs)
+- [Light source code](https://github.com/CommunityToolkit/WindowsCommunityToolkit/tree/rel/7.1.0/Microsoft.Toolkit.Uwp.UI.Animations/Xaml)
 
 ## Related Topics
 


### PR DESCRIPTION
Fixing broken links

Line 101 removed the whole link and text, for line 112 since The Light effect has been removed from the Windows Community Toolkit, I used to link to GitHub (https://github.com/CommunityToolkit/WindowsCommunityToolkit/tree/rel/7.1.0/Microsoft.Toolkit.Uwp.UI.Animations/Xaml) instead.
