### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/docs/animations/Rotate.md
+++ b/docs/animations/Rotate.md
@@ -115,7 +115,7 @@ You can change the way how the animation interpolates between keyframes by defin
 
 ## Sample Project
 
-[Rotate Behavior Sample Page Source](https://github.com/windows-toolkit/WindowsCommunityToolkit/tree/rel/7.1.0/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Rotate). You can [see this in action](uwpct://Animations?sample=Rotate) in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
+You can see this in action in the [Windows Community Toolkit Sample App](https://aka.ms/windowstoolkitapp).
 
 ## Requirements
 


### PR DESCRIPTION
Removed broken link and text line 118, this behavior is no longer available in the Windows Community Toolkit
