### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ We will merge updates from the current main branch to the latest dev branch to k
 
 ## Documentation Links
 
-- [Staging review from 'main' branch](https://review.docs.microsoft.com/windows/uwpcommunitytoolkit/?branch=main)
-- [Live site from 'live' branch](https://docs.microsoft.com/windows/uwpcommunitytoolkit)
+- [Staging review from 'main' branch](https://review.learn.microsoft.com/windows/uwpcommunitytoolkit/?branch=main)
+- [Live site from 'live' branch](https://learn.microsoft.com/windows/uwpcommunitytoolkit)
 
 ## Microsoft Open Source Code of Conduct
 

--- a/docs/.template.md
+++ b/docs/.template.md
@@ -7,10 +7,10 @@ dev_langs:
   - csharp
 ---
 
-<!-- To know about all the available Markdown syntax, Check out https://docs.microsoft.com/en-us/contribute/markdown-reference -->
+<!-- To know about all the available Markdown syntax, Check out https://learn.microsoft.com/contribute/markdown-reference -->
 <!-- Ensure you remove all comments before submission, to ensure that there are no formatting issues when displaying this page.  -->
 <!-- It is recommended to check how the Documentation will look in the sample app, before Merging a PR -->
-<!-- **Note:** All links to other docs.microsoft.com pages should be relative without locale, i.e. for the one above would be /contribute/markdown-reference -->
+<!-- **Note:** All links to other learn.microsoft.com pages should be relative without locale, i.e. for the one above would be /contribute/markdown-reference -->
 <!-- Included images should be optimized for size and not include any Intellectual Property references. -->
 <!-- When linking to the Community Toolkit repo for source references include the specific rel/#.#.# version path of the expected release version, this ensures code will be accessible by docs if it is refactored or moved during development of the next release. -->
 

--- a/docs/gaze/GazeInteractionLibrary.md
+++ b/docs/gaze/GazeInteractionLibrary.md
@@ -189,8 +189,8 @@ private void OnInvokeProgress(object sender, DwellProgressEventArgs e)
 ```
 
 <!-- All control/helper must at least have an example to show the use of Properties and Methods in your control/helper with the output -->
-<!-- Use <example> and <code> tags in C# to create a Propertie/method specific examples. For more info - https://docs.microsoft.com/dotnet/csharp/programming-guide/xmldoc/example -->
-<!-- Optional: Codes to achieve real-world use case with the output. For eg: Check https://docs.microsoft.com/windows/communitytoolkit/animations/animationset#examples  -->
+<!-- Use <example> and <code> tags in C# to create a Propertie/method specific examples. For more info - https://learn.microsoft.com/dotnet/csharp/programming-guide/xmldoc/example -->
+<!-- Optional: Codes to achieve real-world use case with the output. For eg: Check https://learn.microsoft.com/windows/communitytoolkit/animations/animationset#examples  -->
 
 ## Sample Project
 

--- a/docs/high-performance/StringPool.md
+++ b/docs/high-performance/StringPool.md
@@ -25,13 +25,13 @@ public static string GetHost(string url)
     // We assume the input might start either with eg. https:// (or other prefix),
     // or directly with the host name. Furthermore, we also assume that the input
     // URL will always have a '/' character right after the host name.
-    // For instance: "https://docs.microsoft.com/dotnet/api/system.string.intern".
+    // For instance: "https://learn.microsoft.com/dotnet/api/system.string.intern".
     int
         prefixOffset = url.AsSpan().IndexOf(stackalloc char[] { ':', '/', '/' }),
         startIndex = prefixOffset == -1 ? 0 : prefixOffset + 3,
         endIndex = url.AsSpan(startIndex).IndexOf('/');
 
-    // In this example, it would be "docs.microsoft.com"
+    // In this example, it would be "learn.microsoft.com"
     ReadOnlySpan<char> span = url.AsSpan(startIndex, endIndex);
 
     return StringPool.Shared.GetOrAdd(span);

--- a/docs/services/GraphLogin.md
+++ b/docs/services/GraphLogin.md
@@ -104,7 +104,7 @@ End Sub
 | Photo | System.Drawing.Image | Profile picture for the logged on user from the Microsoft Graph |
 | GraphServiceClient | Microsoft.Graph.GraphServiceClient | The GraphServiceClient instance for the logged on user from the Microsoft Graph |
 
-<!-- Use <remarks> tag in C# to give more info about a propertie. For more info - https://docs.microsoft.com/dotnet/csharp/programming-guide/xmldoc/remarks -->
+<!-- Use <remarks> tag in C# to give more info about a propertie. For more info - https://learn.microsoft.com/dotnet/csharp/programming-guide/xmldoc/remarks -->
 
 ## Methods
 


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
