### PR TITLE
LinkFix: WindowsCommunityToolkitDocs (2023-03)

### DIFF
--- a/docs/graph/authentication/ProviderManager.md
+++ b/docs/graph/authentication/ProviderManager.md
@@ -9,7 +9,7 @@ dev_langs:
 
 # ProviderManager
 
-The ProviderManager manages access to the globally configured [IProvider](./custom.md) instance and any state change events as users sign in and out.
+The ProviderManager manages access to the globally configured [IProvider](/graph/authentication/iprovider) instance and any state change events as users sign in and out.
 
 Available in the `CommunityToolkit.Authentication` package.
 

--- a/docs/graph/authentication/overview.md
+++ b/docs/graph/authentication/overview.md
@@ -13,19 +13,19 @@ Authentication is always the first step to working with Microsoft Graph. The too
 
 You can use the providers on their own, without components, to quickly implement authentication for your app and make calls to Microsoft Graph via the Microsoft Graph .NET SDK.
 
-The providers are required when using the Microsoft Graph Toolkit helpers and controls so they can access Microsoft Graph APIs. If you already have your own authentication and want to use the helpers and controls, you can use a [custom provider](./custom.md) instead.
+The providers are required when using the Microsoft Graph Toolkit helpers and controls so they can access Microsoft Graph APIs. If you already have your own authentication and want to use the helpers and controls, you can use a [custom provider](/graph/authentication/iprovider) instead.
 
 The toolkit includes the following providers:
 
 | Providers | Description |
 | -- | -- |
-| [Msal](./msal.md) | Uses MSAL for .NET to sign in users and acquire tokens to use with Microsoft Graph in NetStandard 2.0 applications. |
-| [Windows](./windows.md) | Uses native WebAccountManager (WAM) APIs to sign in users and acquire tokens to use with Microsoft Graph in UWP applications. |
-| [Custom](./custom.md) | Create a custom provider to enable authentication and access to Microsoft Graph with your application's existing authentication code. |
+| [Msal](/graph/authentication/msalprovider) | Uses MSAL for .NET to sign in users and acquire tokens to use with Microsoft Graph in NetStandard 2.0 applications. |
+| [Windows](/graph/authentication/windowsprovider) | Uses native WebAccountManager (WAM) APIs to sign in users and acquire tokens to use with Microsoft Graph in UWP applications. |
+| [Custom](/graph/authentication/iprovider) | Create a custom provider to enable authentication and access to Microsoft Graph with your application's existing authentication code. |
 
 ## Initializing the GlobalProvider
 
-To use an authentication provider in your app, you need to set it as the global provider. The [ProviderManager](./ProviderManager.md) is the singleton that stores the globally accessible [IProvider](./custom.md) implementation and signals events in response to authentication state changes.
+To use an authentication provider in your app, you need to set it as the global provider. The [ProviderManager](./ProviderManager.md) is the singleton that stores the globally accessible [IProvider](/graph/authentication/iprovider) implementation and signals events in response to authentication state changes.
 Set the `GlobalProvider` property at app startup and any other Graph based code will respond to any changes as users sign in and out.
 
 ```csharp

--- a/docs/graph/getting-started.md
+++ b/docs/graph/getting-started.md
@@ -15,7 +15,7 @@ To get started using Graph data in your application, you'll first need to enable
 
 ### Authenticate with MSAL
 
-Leverage the official Microsoft Authentication Library (MSAL) to enable authentication in NetStandard 2.0 applications using [MsalProvider](./authentication/msal.md).
+Leverage the official Microsoft Authentication Library (MSAL) to enable authentication in NetStandard 2.0 applications using [MsalProvider](/graph/authentication/msalprovider).
 
 1. Register your app in Azure AAD
 
@@ -23,7 +23,7 @@ Leverage the official Microsoft Authentication Library (MSAL) to enable authenti
 
     > After finishing the initial registration page, you will also need to add an additional redirect URI. Click on "Add a Redirect URI", then "Add a platform", and then on "Mobile and desktop applications". Check the `https://login.microsoftonline.com/common/oauth2/nativeclient` checkbox on that page. Then click "Configure".
 1. Install the `CommunityToolkit.Authentication.Msal` package.
-1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [MsalProvider](./authentication/msal.md) with clientId and pre-configured scopes:
+1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [MsalProvider](/graph/authentication/msalprovider) with clientId and pre-configured scopes:
 
     ```csharp
     using CommunityToolkit.Authentication;
@@ -38,11 +38,11 @@ Leverage the official Microsoft Authentication Library (MSAL) to enable authenti
 
 ### Authenticate with WindowsProvider
 
-Try out the [WindowsProvider](./authentication/windows.md) to enable authentication based on the native Windows Account Manager (WAM) APIs in your UWP apps, without requiring a dependency on MSAL.
+Try out the [WindowsProvider](/graph/authentication/windowsprovider) to enable authentication based on the native Windows Account Manager (WAM) APIs in your UWP apps, without requiring a dependency on MSAL.
 
-1. Associate your app with the Microsoft Store. The app association will act as our minimal app registration for authenticating consumer MSAs. See [WindowsProvider](./authentication/windows.md) for more details.
+1. Associate your app with the Microsoft Store. The app association will act as our minimal app registration for authenticating consumer MSAs. See [WindowsProvider](/graph/authentication/windowsprovider) for more details.
 1. Install the `CommunityToolkit.Authentication.Uwp` package
-1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [WindowsProvider](./authentication/windows.md) with pre-configured scopes:
+1. Set the [ProviderManager](./authentication/ProviderManager.md).GlobalProvider to a new instance of [WindowsProvider](/graph/authentication/windowsprovider) with pre-configured scopes:
 
     ```csharp
     using CommunityToolkit.Authentication;

--- a/docs/graph/helpers/extensions.md
+++ b/docs/graph/helpers/extensions.md
@@ -13,7 +13,7 @@ Use toolkit extensions to help you make calls to Graph APIs using the global aut
 
 ## Call Microsoft Graph APIs
 
-Once authenticated, you can make API calls to Microsoft Graph using a preconfigured `GraphServiceClient` instance. Access to the client is enabled through an extension method on [IProvider](../authentication/custom.md) called, `GetClient()`.
+Once authenticated, you can make API calls to Microsoft Graph using a preconfigured `GraphServiceClient` instance. Access to the client is enabled through an extension method on [IProvider](/graph/authentication/iprovider) called, `GetClient()`.
 
 ```csharp
 using CommunityToolkit.Authentication;

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -17,63 +17,63 @@
 
 ## MVVM
 
-### [Introduction](mvvm/Introduction.md)
+### [Introduction](/dotnet/communitytoolkit/mvvm/)
 
 ### ComponentModel
 
-#### [ObservableObject](mvvm/ObservableObject.md)
+#### [ObservableObject](/dotnet/communitytoolkit/mvvm/observableobject)
 
-#### [ObservableRecipient](mvvm/ObservableRecipient.md)
+#### [ObservableRecipient](/dotnet/communitytoolkit/mvvm/observablerecipient)
 
-#### [ObservableValidator](mvvm/ObservableValidator.md)
+#### [ObservableValidator](/dotnet/communitytoolkit/mvvm/observablevalidator)
 
 ### Input
 
-#### [RelayCommand and RelayCommand\<T>](mvvm/RelayCommand.md)
+#### [RelayCommand and RelayCommand\<T>](/dotnet/communitytoolkit/mvvm/relaycommand)
 
-#### [AsyncRelayCommand and AsyncRelayCommand\<T>](mvvm/AsyncRelayCommand.md)
+#### [AsyncRelayCommand and AsyncRelayCommand\<T>](/dotnet/communitytoolkit/mvvm/asyncrelaycommand)
 
-### [Messenger](mvvm/Messenger.md)
+### [Messenger](/dotnet/communitytoolkit/mvvm/messenger)
 
-### [Ioc](mvvm/Ioc.md)
+### [Ioc](/dotnet/communitytoolkit/mvvm/ioc)
 
-### [Putting things together](mvvm/PuttingThingsTogether.md)
+### [Putting things together](/dotnet/communitytoolkit/mvvm/puttingthingstogether)
 
 ### Migrating to the MVVM Toolkit
 
-#### [Migrating from MvvmLight](mvvm/MigratingFromMvvmLight.md)
+#### [Migrating from MvvmLight](/dotnet/communitytoolkit/mvvm/migratingfrommvvmlight)
 
-#### [Migrating from MvvmBasic](mvvm/MigratingFromMvvmBasic.md)
+#### [Migrating from MvvmBasic](/dotnet/communitytoolkit/mvvm/migratingfrommvvmbasic)
 
 ## High performance
 
-### [Introduction](high-performance/Introduction.md)
+### [Introduction](/dotnet/communitytoolkit/high-performance/introduction)
 
 ### Buffers
 
-#### [MemoryOwner\<T>](high-performance/MemoryOwner.md)
+#### [MemoryOwner\<T>](/dotnet/communitytoolkit/high-performance/memoryowner)
 
-#### [SpanOwner\<T>](high-performance/SpanOwner.md)
+#### [SpanOwner\<T>](/dotnet/communitytoolkit/high-performance/spanowner)
 
-#### [StringPool](high-performance/StringPool.md)
+#### [StringPool](/dotnet/communitytoolkit/high-performance/stringpool)
 
 ### Memory
 
-#### [Memory2D\<T>](high-performance/Memory2D.md)
+#### [Memory2D\<T>](/dotnet/communitytoolkit/high-performance/memory2d)
 
-#### [Span2D\<T>](high-performance/Span2D.md)
+#### [Span2D\<T>](/dotnet/communitytoolkit/high-performance/span2d)
 
-### [ParallelHelper](high-performance/ParallelHelper.md)
+### [ParallelHelper](/dotnet/communitytoolkit/high-performance/parallelhelper)
 
-### [Ref\<T> and ReadOnlyRef\<T>](high-performance/Ref.md)
+### [Ref\<T> and ReadOnlyRef\<T>](/dotnet/communitytoolkit/high-performance/ref)
 
 ## Diagnostics
 
-### [Introduction](diagnostics/Introduction.md)
+### [Introduction](/dotnet/communitytoolkit/diagnostics/introduction)
 
-### [Guard](developer-tools/Guard.md)
+### [Guard](/dotnet/communitytoolkit/diagnostics/guard)
 
-### [ThrowHelper](developer-tools/ThrowHelper.md)
+### [ThrowHelper](/dotnet/communitytoolkit/diagnostics/throwhelper)
 
 # Microsoft Graph
 
@@ -87,11 +87,11 @@
 
 ### [ProviderManager](graph/authentication/ProviderManager.md)
 
-### [MSAL provider](graph/authentication/msal.md)
+### [MSAL provider](/graph/authentication/msalprovider)
 
-### [Windows provider](graph/authentication/windows.md)
+### [Windows provider](/graph/authentication/windowsprovider)
 
-### [Custom provider](graph/authentication/custom.md)
+### [Custom provider](/graph/authentication/iprovider)
 
 ## Helpers
 
@@ -503,9 +503,9 @@
 
 ### [SharePointFileList](archive/graph/SharePointFileList.md)
 
-### [InteractiveProviderBehavior](archive/graph/providers/InteractiveProviderBehavior.md)
+### [InteractiveProviderBehavior](/graph/providers/interactiveproviderbehavior)
 
-### [MockProviderBehavior](archive/graph/providers/MockProviderBehavior.md)
+### [MockProviderBehavior](/graph/providers/mockproviderbehavior)
 
 ## Parsers
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -531,4 +531,4 @@
 
 ### [Twitter Service](services/Twitter.md)
 
-### [Weibo Service](services/Weibo.md)
+### [Weibo Service](services/Weibo.md)\


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 