### PR TITLE
Update docfx.json

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -41,7 +41,7 @@
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/WindowsCommunityToolkitDocs",
       "feedback_product_url": "https://github.com/windows-toolkit/WindowsCommunityToolkit/issues",
-      "uhfHeaderId": "MSDocsHeader-UWP-Community",
+      "uhfHeaderId": "MSDocsHeader-Windows",
       "ms.topic": "article",
       "ms.prod": "dotnet-communitytoolkit",
       "products": ["https://authoring-docs-microsoft.poolparty.biz/devrel/bcbcbad5-4208-4783-8035-8481272c98b8"],


### PR DESCRIPTION
## What changes to the docs does this PR provide?
This PR changes the uhfHeaderId value to MSDocsWindows. In order to meet platform architectural requirements, this content must use the Windows header. This PR makes that change. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Correctly picked the right branch to base the change off (`dev` for new features, `main` for typos/improvements)
- [ ] For new pages, used the [provided template](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/main/docs/.template.md)
- [ ] For new features, added an entry in the [Table of Contents](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/main/docs/toc.md)
- [x] Ran against a spell and grammar checker
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
