### PR TITLE
Update Node.js version for markdownlint

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -16,17 +16,16 @@ on:
 
 jobs:
   lint:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
-    - name: Use Node.js
-      uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d #@v1
-      with:
-        node-version: 12.x
-    - name: Run Markdownlint
-      run: |
-        echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-        npm i -g markdownlint-cli
-        markdownlint "**/*.md"
+      - uses: actions/checkout@v4.1.1
+      - name: Use Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version: 16.x
+      - name: Run Markdownlint
+        run: |
+          echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
+          npm i -g markdownlint-cli
+          markdownlint "**/*.md"


### PR DESCRIPTION
To fix markdownlint failure in https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/actions/runs/8147303654/job/22267708267?pr=707.